### PR TITLE
EVM-C update

### DIFF
--- a/evm.h
+++ b/evm.h
@@ -41,7 +41,12 @@ enum {
 /// The Host MAY pass the pointer to the Host execution context to
 /// ::evm_execute_fn. The EVM MUST pass the same pointer back to the Host in
 /// every callback function.
-struct evm_context {};
+struct evm_context {
+
+    /// @todo Move evm_host here. We need it now, because structs cannot be
+    ///       empty in C.
+    void* future_fn_table;
+};
 
 /// Big-endian 256-bit integer.
 ///

--- a/evm.h
+++ b/evm.h
@@ -36,18 +36,6 @@ enum {
     EVM_ABI_VERSION = 0
 };
 
-/// Opaque structure representing execution context managed by the Host.
-///
-/// The Host MAY pass the pointer to the Host execution context to
-/// ::evm_execute_fn. The EVM MUST pass the same pointer back to the Host in
-/// every callback function.
-struct evm_context {
-
-    /// @todo Move evm_host here. We need it now, because structs cannot be
-    ///       empty in C.
-    void* future_fn_table;
-};
-
 /// Big-endian 256-bit integer.
 ///
 /// 32 bytes of data representing big-endian 256-bit integer. I.e. bytes[0] is
@@ -100,6 +88,8 @@ struct evm_tx_context {
     int64_t block_gas_limit;
     struct evm_uint256be block_difficulty;
 };
+
+struct evm_context;
 
 typedef void (*evm_get_tx_context_fn)(struct evm_tx_context* result,
                                       struct evm_context* context);
@@ -325,6 +315,21 @@ struct evm_host {
 };
 
 
+/// Execution context managed by the Host.
+///
+/// The Host MUST pass the pointer to the execution context to
+/// ::evm_execute_fn. The EVM MUST pass the same pointer back to the Host in
+/// every callback function.
+/// The context MUST contain at least the function table defining the context
+/// callback interface.
+/// Optionally, The Host MAY include in the context additional data.
+struct evm_context {
+
+    /// Function table defining the context interface.
+    const struct evm_host* fn_table;
+};
+
+
 struct evm_instance;  ///< Forward declaration.
 
 /// Creates the EVM instance.
@@ -332,10 +337,8 @@ struct evm_instance;  ///< Forward declaration.
 /// Creates and initializes an EVM instance by providing the information
 /// about runtime callback functions.
 ///
-/// @param host  Pointer to an EVM Host controlling the created EVM
-///              instance. MUST NOT be null.
 /// @return      Pointer to the created EVM instance.
-typedef struct evm_instance* (*evm_create_fn)(const struct evm_host* host);
+typedef struct evm_instance* (*evm_create_fn)();
 
 /// Destroys the EVM instance.
 ///

--- a/evm.h
+++ b/evm.h
@@ -1,6 +1,7 @@
 /// EVM-C -- C interface to Ethereum Virtual Machine
 ///
 /// ## High level design rules
+///
 /// 1. Pass function arguments and results by value.
 ///    This rule comes from modern C++ and tries to avoid costly alias analysis
 ///    needed for optimization. As the result we have a lots of complex structs
@@ -10,251 +11,331 @@
 ///    The interface also tries to match host application "natural" endianess.
 ///    I would like to know what endianess you use and where.
 ///
+/// ## Terms
+///
+/// 1. EVM  -- an Ethereum Virtual Machine instance/implementation.
+/// 2. Host -- an entity controlling the EVM. The Host requests code execution
+///            and responses to EVM queries by callback functions.
+///
 /// @defgroup EVMC EVM-C
 /// @{
-#pragma once
+#ifndef EVM_H
+#define EVM_H
 
 #include <stdint.h>    // Definition of int64_t, uint64_t.
 #include <stddef.h>    // Definition of size_t.
-#include <stdbool.h>   // Definition of bool.
-
-/// Allow implementation to inject some additional information about function
-/// linkage and/or symbol visibility in the output library.
-#ifndef EXPORT
-#define EXPORT
-#endif
 
 #if __cplusplus
 extern "C" {
 #endif
 
-/// Host-endian 256-bit integer.
-///
-/// 32 bytes of data representing host-endian (that means little-endian almost
-/// all the time) 256-bit integer. This applies to the words[] order as well.
-/// words[0] contains the 64 lowest precision bits, words[3] constains the 64
-/// highest precision bits.
-struct evm_uint256 {
-    /// The 4 64-bit words of the integer. Memory aligned to 8 bytes.
-    uint64_t words[4];
+// BEGIN Python CFFI declarations
+
+enum {
+    /// The EVM-C ABI version number of the interface declared in this file.
+    EVM_ABI_VERSION = 0
 };
 
-/// 160-bit hash suitable for keeping an Ethereum address.
-struct evm_hash160 {
+/// Opaque structure representing execution context managed by the Host.
+///
+/// The Host MAY pass the pointer to the Host execution context to
+/// ::evm_execute_fn. The EVM MUST pass the same pointer back to the Host in
+/// every callback function.
+struct evm_context {};
+
+/// Big-endian 256-bit integer.
+///
+/// 32 bytes of data representing big-endian 256-bit integer. I.e. bytes[0] is
+/// the most significant byte, bytes[31] is the least significant byte.
+/// This type is used to transfer to/from the VM values interpreted by the user
+/// as both 256-bit integers and 256-bit hashes.
+struct evm_uint256be {
+    /// The 32 bytes of the big-endian integer or hash.
+    uint8_t bytes[32];
+};
+
+/// Big-endian 160-bit hash suitable for keeping an Ethereum address.
+/// TODO: Rename to "address".
+struct evm_uint160be {
     /// The 20 bytes of the hash.
     uint8_t bytes[20];
 };
-
-
-/// Big-endian 256-bit integer/hash.
-///
-/// 32 bytes of data. For EVM that means big-endian 256-bit integer. Values of
-/// this type are converted to host-endian values inside EVM.
-struct evm_hash256 {
-    union {
-        /// The 32 bytes of the integer/hash. Memory aligned to 8 bytes.
-        uint8_t bytes[32];
-        /// Additional access by uint64 words to enforce 8 bytes alignment.
-        uint64_t words[4];
-    };
-};
-
-
-#define EVM_EXCEPTION INT64_MIN  ///< The execution ended with an exception.
-
-/// Complex struct representing execution result.
-struct evm_result {
-    /// Gas left after execution or exception indicator.
-    int64_t gas_left;
-
-    /// Rerefence to output data. The memory containing the output data
-    /// is owned by EVM and is freed with evm_destroy_result().
-    uint8_t const* output_data;
-
-    /// Size of the output data.
-    size_t output_size;
-
-    /// Pointer to EVM-owned memory.
-    /// @see output_data.
-    void* internal_memory;
-};
-
-/// The query callback key.
-enum evm_query_key {
-    EVM_SLOAD = 0,            ///< Storage value of a given key for SLOAD.
-    EVM_ADDRESS = 1,          ///< Address of the contract for ADDRESS.
-    EVM_CALLER = 2,           ///< Message sender address for CALLER.
-    EVM_ORIGIN = 3,           ///< Transaction origin address for ORIGIN.
-    EVM_GAS_PRICE = 4,        ///< Transaction gas price for GASPRICE.
-    EVM_COINBASE = 5,         ///< Current block miner address for COINBASE.
-    EVM_DIFFICULTY = 6,       ///< Current block difficulty for DIFFICULTY.
-    EVM_GAS_LIMIT = 7,        ///< Current block gas limit for GASLIMIT.
-    EVM_NUMBER = 8,           ///< Current block number for NUMBER.
-    EVM_TIMESTAMP = 9,        ///< Current block timestamp for TIMESTAMP.
-    EVM_CODE_BY_ADDRESS = 10, ///< Code by an address for EXTCODE/SIZE.
-    EVM_BALANCE = 11,         ///< Balance of a given address for BALANCE.
-    EVM_BLOCKHASH = 12        ///< Block hash of by block number for BLOCKHASH.
-};
-
-
-/// Opaque struct representing execution enviroment managed by the host
-/// application.
-struct evm_env;
-
-/// Variant type to represent possible types of values used in EVM.
-///
-/// Type-safety is lost around the code that uses this type. We should have
-/// complete set of unit tests covering all possible cases.
-/// The size of the type is 64 bytes and should fit in single cache line.
-union evm_variant {
-    /// A host-endian 64-bit integer.
-    int64_t int64;
-
-    /// A host-endian 256-bit integer.
-    struct evm_uint256 uint256;
-
-    /// A big-endian 256-bit integer/hash.
-    struct evm_hash256 hash256;
-
-    struct {
-        /// Additional padding to align the evm_variant::address with lower
-        /// bytes of a full 256-bit hash.
-        uint8_t address_padding[12];
-
-        /// An Ethereum address.
-        struct evm_hash160 address;
-    };
-
-    /// A memory reference.
-    struct {
-        /// Pointer to the data.
-        uint8_t const* data;
-
-        /// Size of the referenced memory/data.
-        size_t data_size;
-    };
-};
-
-/// Query callback function.
-///
-/// This callback function is used by the EVM to query the host application
-/// about additional data required to execute EVM code.
-/// @param env  Pointer to execution environment managed by the host
-///             application.
-/// @param key  The kind of the query. See evm_query_key and details below.
-/// @param arg  Additional argument to the query. It has defined value only for
-///             the subset of query keys.
-///
-/// ## Types of queries
-/// Key                   | Arg                  | Expected result
-/// ----------------------| -------------------- | ----------------------------
-/// ::EVM_GAS_PRICE       |                      | evm_variant::uint256
-/// ::EVM_ADDRESS         |                      | evm_variant::address
-/// ::EVM_CALLER          |                      | evm_variant::address
-/// ::EVM_ORIGIN          |                      | evm_variant::address
-/// ::EVM_COINBASE        |                      | evm_variant::address
-/// ::EVM_DIFFICULTY      |                      | evm_variant::uint256
-/// ::EVM_GAS_LIMIT       |                      | evm_variant::int64
-/// ::EVM_NUMBER          |                      | evm_variant::int64?
-/// ::EVM_TIMESTAMP       |                      | evm_variant::int64?
-/// ::EVM_CODE_BY_ADDRESS | evm_variant::address | evm_variant::bytes
-/// ::EVM_BALANCE         | evm_variant::address | evm_variant::uint256
-/// ::EVM_BLOCKHASH       | evm_variant::int64   | evm_variant::uint256
-/// ::EVM_SLOAD           | evm_variant::uint256 | evm_variant::uint256?
-typedef union evm_variant (*evm_query_fn)(struct evm_env* env,
-                                          enum evm_query_key key,
-                                          union evm_variant arg);
-
-/// The update callback key.
-enum evm_update_key {
-    EVM_SSTORE = 0,        ///< Update storage entry
-    EVM_LOG = 1,           ///< Log.
-    EVM_SELFDESTRUCT = 2,  ///< Mark contract as selfdestructed and set
-                           ///  beneficiary address.
-};
-
-
-/// Callback function for modifying a contract state.
-typedef void (*evm_update_fn)(struct evm_env* env,
-                              enum evm_update_key key,
-                              union evm_variant arg1,
-                              union evm_variant arg2);
 
 /// The kind of call-like instruction.
 enum evm_call_kind {
     EVM_CALL = 0,         ///< Request CALL.
     EVM_DELEGATECALL = 1, ///< Request DELEGATECALL. The value param ignored.
     EVM_CALLCODE = 2,     ///< Request CALLCODE.
-    EVM_CREATE = 3        ///< Request CREATE. Semantic of some params changes.
+    EVM_CREATE = 3,       ///< Request CREATE. Semantic of some params changes.
 };
+
+enum evm_flags {
+    EVM_STATIC = 1
+};
+
+struct evm_message {
+    struct evm_uint160be address;
+    struct evm_uint160be sender;
+    struct evm_uint256be value;
+    const uint8_t* input;
+    size_t input_size;
+    struct evm_uint256be code_hash;
+    int64_t gas;
+    int32_t depth;
+    enum evm_call_kind kind;
+    uint32_t flags;
+};
+
+struct evm_tx_context {
+    struct evm_uint256be tx_gas_price;
+    struct evm_uint160be tx_origin;
+    struct evm_uint160be block_coinbase;
+    int64_t block_number;
+    int64_t block_timestamp;
+    int64_t block_gas_limit;
+    struct evm_uint256be block_difficulty;
+};
+
+typedef void (*evm_get_tx_context_fn)(struct evm_tx_context* result,
+                                      struct evm_context* context);
+
+typedef void (*evm_get_block_hash_fn)(struct evm_uint256be* result,
+                                      struct evm_context* context,
+                                      int64_t number);
+
+/// The execution result code.
+enum evm_result_code {
+    EVM_SUCCESS = 0,               ///< Execution finished with success.
+    EVM_FAILURE = 1,               ///< Generic execution failure.
+    EVM_OUT_OF_GAS = 2,
+    EVM_BAD_INSTRUCTION = 3,
+    EVM_BAD_JUMP_DESTINATION = 4,
+    EVM_STACK_OVERFLOW = 5,
+    EVM_STACK_UNDERFLOW = 6,
+    EVM_REVERT = 7,  ///< Execution terminated with REVERT opcode.
+
+    /// EVM implementation internal error.
+    ///
+    /// FIXME: We should rethink reporting internal errors. One of the options
+    /// it to allow using any negative value to represent internal errors.
+    EVM_INTERNAL_ERROR = -1,
+};
+
+struct evm_result;  ///< Forward declaration.
+
+/// Releases resources assigned to an execution result.
+///
+/// This function releases memory (and other resources, if any) assigned to the
+/// specified execution result making the result object invalid.
+///
+/// @param result  The execution result which resource are to be released. The
+///                result itself it not modified by this function, but becomes
+///                invalid and user should discard it as well.
+typedef void (*evm_release_result_fn)(struct evm_result const* result);
+
+/// The EVM code execution result.
+struct evm_result {
+    /// The execution result code.
+    /// FIXME: Rename to 'status' or 'status_code'.
+    enum evm_result_code code;
+
+    /// The amount of gas left after the execution.
+    ///
+    /// If evm_result::code is not ::EVM_SUCCESS nor ::EVM_REVERT
+    /// the value MUST be 0.
+    int64_t gas_left;
+
+    /// The reference to output data.
+    ///
+    /// The output contains data coming from RETURN opcode (iff evm_result::code
+    /// field is ::EVM_SUCCESS) or from REVERT opcode.
+    ///
+    /// The memory containing the output data is owned by EVM and has to be
+    /// freed with evm_result::release().
+    uint8_t const* output_data;
+
+    /// The size of the output data.
+    size_t output_size;
+
+    /// The pointer to a function releasing all resources associated with
+    /// the result object.
+    ///
+    /// This function pointer is optional (MAY be NULL) and MAY be set by
+    /// the EVM implementation. If set it MUST be used by the user to
+    /// release memory and other resources associated with the result object.
+    /// After the result resources are released the result object
+    /// MUST NOT be used any more.
+    ///
+    /// The suggested code pattern for releasing EVM results:
+    /// @code
+    /// struct evm_result result = ...;
+    /// if (result.release)
+    ///     result.release(&result);
+    /// @endcode
+    ///
+    /// @note
+    /// It works similarly to C++ virtual destructor. Attaching the release
+    /// function to the result itself allows EVM composition.
+    evm_release_result_fn release;
+
+    /// Reserved data that MAY be used by a evm_result object creator.
+    ///
+    /// This reserved 24 bytes extends the size of the evm_result to 64 bytes
+    /// (full cache line).
+    /// An EVM implementation MAY use this memory to keep additional data
+    /// when returning result from ::evm_execute_fn.
+    /// The host application MAY use this memory to keep additional data
+    /// when returning result of performed calls from ::evm_call_fn.
+    union
+    {
+        void* context;     ///< A pointer for storing external objects.
+        uint8_t data[24];  ///< 24 bytes of reserved data.
+    } reserved;
+};
+
+/// Check account existence callback function
+///
+/// This callback function is used by the EVM to check if
+/// there exists an account at given address.
+/// @param      context  The pointer to the Host execution context.
+///                      @see ::evm_context.
+/// @param      address  The address of the account the query is about.
+/// @return              1 if exists, 0 otherwise.
+typedef int (*evm_account_exists_fn)(struct evm_context* context,
+                                     const struct evm_uint160be* address);
+
+/// Get storage callback function.
+///
+/// This callback function is used by an EVM to query the given contract
+/// storage entry.
+/// @param[out] result   The returned storage value.
+/// @param      context  The pointer to the Host execution context.
+///                      @see ::evm_context.
+/// @param      address  The address of the contract.
+/// @param      key      The index of the storage entry.
+typedef void (*evm_get_storage_fn)(struct evm_uint256be* result,
+                                   struct evm_context* context,
+                                   const struct evm_uint160be* address,
+                                   const struct evm_uint256be* key);
+
+/// Set storage callback function.
+///
+/// This callback function is used by an EVM to update the given contract
+/// storage entry.
+/// @param context  The pointer to the Host execution context.
+///                 @see ::evm_context.
+/// @param address  The address of the contract.
+/// @param key      The index of the storage entry.
+/// @param value    The value to be stored.
+typedef void (*evm_set_storage_fn)(struct evm_context* context,
+                                   const struct evm_uint160be* address,
+                                   const struct evm_uint256be* key,
+                                   const struct evm_uint256be* value);
+
+/// Get balance callback function.
+///
+/// This callback function is used by an EVM to query the balance of the given
+/// address.
+/// @param[out] result   The returned balance value.
+/// @param      context  The pointer to the Host execution context.
+///                      @see ::evm_context.
+/// @param      address  The address.
+typedef void (*evm_get_balance_fn)(struct evm_uint256be* result,
+                                   struct evm_context* context,
+                                   const struct evm_uint160be* address);
+
+/// Get code callback function.
+///
+/// This callback function is used by an EVM to get the code of a contract of
+/// given address.
+/// @param[out] result_code  The pointer to the contract code. This argument is
+///                          optional. If NULL is provided, the host MUST only
+///                          return the code size.
+/// @param      context      The pointer to the Host execution context.
+///                          @see ::evm_context.
+/// @param      address      The address of the contract.
+/// @return                  The size of the code.
+typedef size_t (*evm_get_code_fn)(const uint8_t** result_code,
+                                  struct evm_context* context,
+                                  const struct evm_uint160be* address);
+
+/// Selfdestruct callback function.
+///
+/// This callback function is used by an EVM to SELFDESTRUCT given contract.
+/// @param context      The pointer to the Host execution context.
+///                     @see ::evm_context.
+/// @param address      The address of the contract to be selfdestructed.
+/// @param beneficiary  The address where the remaining ETH is going to be
+///                     transferred.
+typedef void (*evm_selfdestruct_fn)(struct evm_context* context,
+                                    const struct evm_uint160be* address,
+                                    const struct evm_uint160be* beneficiary);
+
+/// Log callback function.
+///
+/// This callback function is used by an EVM to inform about a LOG that happened
+/// during an EVM bytecode execution.
+/// @param context       The pointer to the Host execution context.
+///                      @see ::evm_context.
+/// @param address       The address of the contract that generated the log.
+/// @param data          The pointer to unindexed data attached to the log.
+/// @param data_size     The length of the data.
+/// @param topics        The pointer to the array of topics attached to the log.
+/// @param topics_count  The number of the topics. Valid values are between
+///                      0 and 4 inclusively.
+typedef void (*evm_log_fn)(struct evm_context* context,
+                           const struct evm_uint160be* address,
+                           const uint8_t* data,
+                           size_t data_size,
+                           const struct evm_uint256be topics[],
+                           size_t topics_count);
 
 /// Pointer to the callback function supporting EVM calls.
 ///
-/// @param env          Pointer to execution environment managed by the host
-///                     application.
-/// @param kind         The kind of call-like opcode requested.
-/// @param gas          The amount of gas for the call.
-/// @param address      The address of a contract to be called. Ignored in case
-///                     of CREATE.
-/// @param value        The value sent to the callee. The endowment in case of
-///                     CREATE.
-/// @param input        The call input data or the create init code.
-/// @param input_size   The size of the input data.
-/// @param output       The reference to the memory where the call output is to
-///                     be copied. In case of create, the memory is guaranteed
-///                     to be at least 160 bytes to hold the address of the
-///                     created contract.
-/// @param output_data  The size of the output data. In case of create, expected
-///                     value is 160.
-/// @return      If non-negative - the amount of gas left,
-///              If negative - an exception occurred during the call/create.
-///              There is no need to set 0 address in the output in this case.
-typedef int64_t (*evm_call_fn)(
-    struct evm_env* env,
-    enum evm_call_kind kind,
-    int64_t gas,
-    struct evm_hash160 address,
-    struct evm_uint256 value,
-    uint8_t const* input,
-    size_t input_size,
-    uint8_t* output,
-    size_t output_size);
+/// @param[out] result  Call result.
+/// @param      context The pointer to the Host execution context.
+///                     @see ::evm_context.
+/// @param      msg     Call parameters.
+typedef void (*evm_call_fn)(struct evm_result* result,
+                            struct evm_context* context,
+                            const struct evm_message* msg);
 
-
-/// A piece of information about the EVM implementation.
-enum evm_info_key {
-    EVM_NAME  = 0,   ///< The name of the EVM implementation. ASCII encoded.
-    EVM_VERSION = 1  ///< The software version of the EVM.
+/// The Host interface.
+///
+/// The set of all callback functions expected by EVM instances. This is C
+/// realisation of OOP interface (only virtual methods, no data).
+/// Host implementations SHOULD create constant singletons of this (similarly
+/// to vtables) to lower the maintenance and memory management cost.
+struct evm_host {
+    evm_account_exists_fn account_exists;
+    evm_get_storage_fn get_storage;
+    evm_set_storage_fn set_storage;
+    evm_get_balance_fn get_balance;
+    evm_get_code_fn get_code;
+    evm_selfdestruct_fn selfdestruct;
+    evm_call_fn call;
+    evm_get_tx_context_fn get_tx_context;
+    evm_get_block_hash_fn get_block_hash;
+    evm_log_fn log;
 };
 
-/// Request information about the EVM implementation.
-///
-/// @param key  What do you want to know?
-/// @return     Requested information as a c-string. Nonnull.
-EXPORT char const* evm_get_info(enum evm_info_key key);
 
-/// Opaque type representing a EVM instance.
-struct evm_instance;
+struct evm_instance;  ///< Forward declaration.
 
-/// Creates new EVM instance.
+/// Creates the EVM instance.
 ///
-/// Creates new EVM instance. The instance must be destroyed in evm_destroy().
-/// Single instance is thread-safe and can be shared by many threads. Having
-/// **multiple instances is safe but discouraged** as it has not benefits over
-/// having the singleton.
+/// Creates and initializes an EVM instance by providing the information
+/// about runtime callback functions.
 ///
-/// @param query_fn   Pointer to query callback function. Nonnull.
-/// @param update_fn  Pointer to update callback function. Nonnull.
-/// @param call_fn    Pointer to call callback function. Nonnull.
-/// @return           Pointer to the created EVM instance.
-EXPORT struct evm_instance* evm_create(evm_query_fn query_fn,
-                                       evm_update_fn update_fn,
-                                       evm_call_fn call_fn);
+/// @param host  Pointer to an EVM Host controlling the created EVM
+///              instance. MUST NOT be null.
+/// @return      Pointer to the created EVM instance.
+typedef struct evm_instance* (*evm_create_fn)(const struct evm_host* host);
 
 /// Destroys the EVM instance.
 ///
 /// @param evm  The EVM instance to be destroyed.
-EXPORT void evm_destroy(struct evm_instance* evm);
+typedef void (*evm_destroy_fn)(struct evm_instance* evm);
 
 
 /// Configures the EVM instance.
@@ -265,19 +346,25 @@ EXPORT void evm_destroy(struct evm_instance* evm);
 /// - optimizations,
 ///
 /// @param evm    The EVM instance to be configured.
-/// @param name   The option name. Cannot be null.
-/// @param value  The new option value. Cannot be null.
-/// @return       True if the option set successfully.
-EXPORT bool evm_set_option(struct evm_instance* evm,
-                           char const* name,
-                           char const* value);
+/// @param name   The option name. NULL-terminated string. Cannot be NULL.
+/// @param value  The new option value. NULL-terminated string. Cannot be NULL.
+/// @return       1 if the option set successfully, 0 otherwise.
+typedef int (*evm_set_option_fn)(struct evm_instance* evm,
+                                 char const* name,
+                                 char const* value);
 
 
-/// EVM compatibility mode aka chain mode.
-/// TODO: Can you suggest better name?
-enum evm_mode {
+/// EVM revision.
+///
+/// The revision of the EVM specification based on the Ethereum
+/// upgrade / hard fork codenames.
+enum evm_revision {
     EVM_FRONTIER = 0,
-    EVM_HOMESTEAD = 1
+    EVM_HOMESTEAD = 1,
+    EVM_TANGERINE_WHISTLE = 2,
+    EVM_SPURIOUS_DRAGON = 3,
+    EVM_BYZANTIUM = 4,
+    EVM_CONSTANTINOPLE = 5,
 };
 
 
@@ -286,9 +373,9 @@ enum evm_mode {
 /// All the fun is here. This function actually does something useful.
 ///
 /// @param instance    A EVM instance.
-/// @param env         A pointer to the execution environment provided by the
-///                    user and passed to callback functions.
-/// @param mode        EVM compatibility mode.
+/// @param context     The pointer to the Host execution context to be passed
+///                    to callback functions. @see ::evm_context.
+/// @param rev         Requested EVM specification revision.
 /// @param code_hash   A hash of the bytecode, usually Keccak. The EVM uses it
 ///                    as the code identifier. A EVM implementation is able to
 ///                    hash the code itself if it requires it, but the host
@@ -300,36 +387,99 @@ enum evm_mode {
 /// @param input_size  The size of the input data.
 /// @param value       Call value.
 /// @return            All execution results.
-EXPORT struct evm_result evm_execute(struct evm_instance* instance,
-                                     struct evm_env* env,
-                                     enum evm_mode mode,
-                                     struct evm_hash256 code_hash,
-                                     uint8_t const* code,
-                                     size_t code_size,
-                                     int64_t gas,
-                                     uint8_t const* input,
-                                     size_t input_size,
-                                     struct evm_uint256 value);
-
-/// Destroys execution result.
-EXPORT void evm_destroy_result(struct evm_result);
+typedef struct evm_result (*evm_execute_fn)(struct evm_instance* instance,
+                                            struct evm_context* context,
+                                            enum evm_revision rev,
+                                            const struct evm_message* msg,
+                                            uint8_t const* code,
+                                            size_t code_size);
 
 
-/// @defgroup EVMJIT EVMJIT extenstion to EVM-C
-/// @{
+/// Status of a code in VM. Useful for JIT-like implementations.
+enum evm_code_status {
+    /// The code is uknown to the VM.
+    EVM_UNKNOWN,
+
+    /// The code has been compiled and is available in memory.
+    EVM_READY,
+
+    /// The compiled version of the code is available in on-disk cache.
+    EVM_CACHED,
+};
 
 
-EXPORT bool evmjit_is_code_ready(struct evm_instance* instance, enum evm_mode mode,
-                                 struct evm_hash256 code_hash);
+/// Get information the status of the code in the VM.
+typedef enum evm_code_status
+(*evm_get_code_status_fn)(struct evm_instance* instance,
+                          enum evm_revision rev,
+                          uint32_t flags,
+                          struct evm_uint256be code_hash);
 
-EXPORT void evmjit_compile(struct evm_instance* instance, enum evm_mode mode,
-                           uint8_t const* code, size_t code_size,
-                           struct evm_hash256 code_hash);
+/// Request preparation of the code for faster execution. It is not required
+/// to execute the code but allows compilation of the code ahead of time in
+/// JIT-like VMs.
+typedef void (*evm_prepare_code_fn)(struct evm_instance* instance,
+                                    enum evm_revision rev,
+                                    uint32_t flags,
+                                    struct evm_uint256be code_hash,
+                                    uint8_t const* code,
+                                    size_t code_size);
 
-/// @}
+/// The EVM instance.
+///
+/// Defines the base struct of the EVM implementation.
+struct evm_instance {
+    /// Pointer to function destroying the EVM instance.
+    evm_destroy_fn destroy;
+
+    /// Pointer to function executing a code by the EVM instance.
+    evm_execute_fn execute;
+
+    /// Optional pointer to function returning a status of a code.
+    ///
+    /// If the VM does not support this feature the pointer can be NULL.
+    evm_get_code_status_fn get_code_status;
+
+    /// Optional pointer to function compiling  a code.
+    ///
+    /// If the VM does not support this feature the pointer can be NULL.
+    evm_prepare_code_fn prepare_code;
+
+    /// Optional pointer to function modifying VM's options.
+    ///
+    /// If the VM does not support this feature the pointer can be NULL.
+    evm_set_option_fn set_option;
+};
+
+/// The EVM instance factory.
+///
+/// Provides ABI protection and method to create an EVM instance.
+struct evm_factory {
+    /// EVM-C ABI version implemented by the EVM factory and instance.
+    ///
+    /// For future use to detect ABI incompatibilities. The EVM-C ABI version
+    /// represented by this file is in ::EVM_ABI_VERSION.
+    int abi_version;
+
+    /// Pointer to function creating and initializing the EVM instance.
+    evm_create_fn create;
+};
+
+// END Python CFFI declarations
+
+/// Example of a function creating uninitialized instance of an example VM.
+///
+/// Each EVM implementation is obligated to provided a function returning
+/// an EVM instance.
+/// The function has to be named as `<vm-name>_get_factory(void)`.
+///
+/// @return  EVM instance.
+struct evm_factory examplevm_get_factory(void);
 
 
 #if __cplusplus
 }
 #endif
+
+#endif  // EVM_H
 /// @}

--- a/evm.h
+++ b/evm.h
@@ -48,8 +48,7 @@ struct evm_uint256be {
 };
 
 /// Big-endian 160-bit hash suitable for keeping an Ethereum address.
-/// TODO: Rename to "address".
-struct evm_uint160be {
+struct evm_address {
     /// The 20 bytes of the hash.
     uint8_t bytes[20];
 };
@@ -67,8 +66,8 @@ enum evm_flags {
 };
 
 struct evm_message {
-    struct evm_uint160be address;
-    struct evm_uint160be sender;
+    struct evm_address address;
+    struct evm_address sender;
     struct evm_uint256be value;
     const uint8_t* input;
     size_t input_size;
@@ -81,8 +80,8 @@ struct evm_message {
 
 struct evm_tx_context {
     struct evm_uint256be tx_gas_price;
-    struct evm_uint160be tx_origin;
-    struct evm_uint160be block_coinbase;
+    struct evm_address tx_origin;
+    struct evm_address block_coinbase;
     int64_t block_number;
     int64_t block_timestamp;
     int64_t block_gas_limit;
@@ -98,8 +97,8 @@ typedef void (*evm_get_block_hash_fn)(struct evm_uint256be* result,
                                       struct evm_context* context,
                                       int64_t number);
 
-/// The execution result code.
-enum evm_result_code {
+/// The execution status code.
+enum evm_status_code {
     EVM_SUCCESS = 0,               ///< Execution finished with success.
     EVM_FAILURE = 1,               ///< Generic execution failure.
     EVM_OUT_OF_GAS = 2,
@@ -107,12 +106,12 @@ enum evm_result_code {
     EVM_BAD_JUMP_DESTINATION = 4,
     EVM_STACK_OVERFLOW = 5,
     EVM_STACK_UNDERFLOW = 6,
-    EVM_REVERT = 7,  ///< Execution terminated with REVERT opcode.
+    EVM_REVERT = 7,                ///< Execution terminated with REVERT opcode.
 
     /// EVM implementation internal error.
     ///
-    /// FIXME: We should rethink reporting internal errors. One of the options
-    /// it to allow using any negative value to represent internal errors.
+    /// @todo We should rethink reporting internal errors. One of the options
+    ///       it to allow using any negative value to represent internal errors.
     EVM_INTERNAL_ERROR = -1,
 };
 
@@ -130,9 +129,8 @@ typedef void (*evm_release_result_fn)(struct evm_result const* result);
 
 /// The EVM code execution result.
 struct evm_result {
-    /// The execution result code.
-    /// FIXME: Rename to 'status' or 'status_code'.
-    enum evm_result_code code;
+    /// The execution status code.
+    enum evm_status_code status_code;
 
     /// The amount of gas left after the execution.
     ///
@@ -197,7 +195,7 @@ struct evm_result {
 /// @param      address  The address of the account the query is about.
 /// @return              1 if exists, 0 otherwise.
 typedef int (*evm_account_exists_fn)(struct evm_context* context,
-                                     const struct evm_uint160be* address);
+                                     const struct evm_address* address);
 
 /// Get storage callback function.
 ///
@@ -210,7 +208,7 @@ typedef int (*evm_account_exists_fn)(struct evm_context* context,
 /// @param      key      The index of the storage entry.
 typedef void (*evm_get_storage_fn)(struct evm_uint256be* result,
                                    struct evm_context* context,
-                                   const struct evm_uint160be* address,
+                                   const struct evm_address* address,
                                    const struct evm_uint256be* key);
 
 /// Set storage callback function.
@@ -223,7 +221,7 @@ typedef void (*evm_get_storage_fn)(struct evm_uint256be* result,
 /// @param key      The index of the storage entry.
 /// @param value    The value to be stored.
 typedef void (*evm_set_storage_fn)(struct evm_context* context,
-                                   const struct evm_uint160be* address,
+                                   const struct evm_address* address,
                                    const struct evm_uint256be* key,
                                    const struct evm_uint256be* value);
 
@@ -237,7 +235,7 @@ typedef void (*evm_set_storage_fn)(struct evm_context* context,
 /// @param      address  The address.
 typedef void (*evm_get_balance_fn)(struct evm_uint256be* result,
                                    struct evm_context* context,
-                                   const struct evm_uint160be* address);
+                                   const struct evm_address* address);
 
 /// Get code callback function.
 ///
@@ -252,7 +250,7 @@ typedef void (*evm_get_balance_fn)(struct evm_uint256be* result,
 /// @return                  The size of the code.
 typedef size_t (*evm_get_code_fn)(const uint8_t** result_code,
                                   struct evm_context* context,
-                                  const struct evm_uint160be* address);
+                                  const struct evm_address* address);
 
 /// Selfdestruct callback function.
 ///
@@ -263,8 +261,8 @@ typedef size_t (*evm_get_code_fn)(const uint8_t** result_code,
 /// @param beneficiary  The address where the remaining ETH is going to be
 ///                     transferred.
 typedef void (*evm_selfdestruct_fn)(struct evm_context* context,
-                                    const struct evm_uint160be* address,
-                                    const struct evm_uint160be* beneficiary);
+                                    const struct evm_address* address,
+                                    const struct evm_address* beneficiary);
 
 /// Log callback function.
 ///
@@ -279,7 +277,7 @@ typedef void (*evm_selfdestruct_fn)(struct evm_context* context,
 /// @param topics_count  The number of the topics. Valid values are between
 ///                      0 and 4 inclusively.
 typedef void (*evm_log_fn)(struct evm_context* context,
-                           const struct evm_uint160be* address,
+                           const struct evm_address* address,
                            const uint8_t* data,
                            size_t data_size,
                            const struct evm_uint256be topics[],
@@ -295,13 +293,13 @@ typedef void (*evm_call_fn)(struct evm_result* result,
                             struct evm_context* context,
                             const struct evm_message* msg);
 
-/// The Host interface.
+/// The context interface.
 ///
 /// The set of all callback functions expected by EVM instances. This is C
-/// realisation of OOP interface (only virtual methods, no data).
+/// realisation of vtable for OOP interface (only virtual methods, no data).
 /// Host implementations SHOULD create constant singletons of this (similarly
 /// to vtables) to lower the maintenance and memory management cost.
-struct evm_host {
+struct evm_context_fn_table {
     evm_account_exists_fn account_exists;
     evm_get_storage_fn get_storage;
     evm_set_storage_fn set_storage;
@@ -325,20 +323,12 @@ struct evm_host {
 /// Optionally, The Host MAY include in the context additional data.
 struct evm_context {
 
-    /// Function table defining the context interface.
-    const struct evm_host* fn_table;
+    /// Function table defining the context interface (vtable).
+    const struct evm_context_fn_table* fn_table;
 };
 
 
 struct evm_instance;  ///< Forward declaration.
-
-/// Creates the EVM instance.
-///
-/// Creates and initializes an EVM instance by providing the information
-/// about runtime callback functions.
-///
-/// @return      Pointer to the created EVM instance.
-typedef struct evm_instance* (*evm_create_fn)();
 
 /// Destroys the EVM instance.
 ///
@@ -437,6 +427,15 @@ typedef void (*evm_prepare_code_fn)(struct evm_instance* instance,
 ///
 /// Defines the base struct of the EVM implementation.
 struct evm_instance {
+
+    /// EVM-C ABI version implemented by the EVM instance.
+    ///
+    /// For future use to detect ABI incompatibilities. The EVM-C ABI version
+    /// represented by this file is in ::EVM_ABI_VERSION.
+    ///
+    /// @todo Consider removing this field.
+    const int abi_version;
+
     /// Pointer to function destroying the EVM instance.
     evm_destroy_fn destroy;
 
@@ -459,30 +458,15 @@ struct evm_instance {
     evm_set_option_fn set_option;
 };
 
-/// The EVM instance factory.
-///
-/// Provides ABI protection and method to create an EVM instance.
-struct evm_factory {
-    /// EVM-C ABI version implemented by the EVM factory and instance.
-    ///
-    /// For future use to detect ABI incompatibilities. The EVM-C ABI version
-    /// represented by this file is in ::EVM_ABI_VERSION.
-    int abi_version;
-
-    /// Pointer to function creating and initializing the EVM instance.
-    evm_create_fn create;
-};
-
 // END Python CFFI declarations
 
-/// Example of a function creating uninitialized instance of an example VM.
+/// Example of a function creating an instance of an example EVM implementation.
 ///
-/// Each EVM implementation is obligated to provided a function returning
-/// an EVM instance.
-/// The function has to be named as `<vm-name>_get_factory(void)`.
+/// Each EVM implementation MUST provide a function returning an EVM instance.
+/// The function SHOULD be named `<vm-name>_create(void)`.
 ///
-/// @return  EVM instance.
-struct evm_factory examplevm_get_factory(void);
+/// @return  EVM instance or NULL indicating instance creation failure.
+struct evm_instance* examplevm_create(void);
 
 
 #if __cplusplus

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -37,7 +37,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
     if (import->base == Name("useGas")) {
       std::cout << "usegas ";
 
-      uint32_t gas = arguments[0].geti32();
+      int64_t gas = arguments[0].geti64();
 
       std::cout << gas << "\n";
 
@@ -54,7 +54,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       std::cout << resultOffset << "\n";
 
       evm_uint160be address;
-      //TODO: address callback fn
+      //TODO: get address of executing account
       copyAddressToMemory(address, resultOffset);
 
       return Literal();
@@ -71,7 +71,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       struct evm_uint160be *address;
       copyAddressFromMemory(address, addressOffset);
       struct evm_uint256be *balance;
-      //TODO: balance callback function with context
+      hera->get_balance_fn(balance, call->context, address);
       copy256ToMemory(balance, resultOffset);
 
       return Literal();
@@ -80,12 +80,12 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
     if (import->base == Name("getBlockHash")) {
       std::cout << "getBlockHash";
 
-      uint32_t number = arguments[0].geti32();
+      int64_t number = arguments[0].geti64();
       uint32_t resultOffset = arguments[1].geti32();
       std::cout << number << " " << resultOffset << "\n";
       
       struct evm_uint256be *blockhash;
-      //TODO: blockhash callback function with context
+      hera->get_block_hash_fn(blockhash, call->context, number);
       copy256ToMemory(blockhash, resultOffset);
 
       return Literal();
@@ -101,7 +101,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       uint32_t resultOffset = arguments[0].geti32();
       uint32_t dataOffset = arguments[1].geti32();
-      uint32_t length = arguments[2].geti32();
+      int32_t length = arguments[2].geti32();
 
       std::cout << resultOffset << " " << dataOffset << " " << length << "\n";
 
@@ -114,7 +114,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       std::cout << "return ";
 
       uint32_t offset = arguments[0].geti32();
-      uint32_t size = arguments[1].geti32();
+      int32_t size = arguments[1].geti32();
 
       std::cout << offset << " " << size << "\n";
 

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -53,13 +53,35 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       std::cout << resultOffset << "\n";
 
-      union evm_variant arg = { .int64 = 0 };
+      union evm_variant arg = { .address = 0 };
       union evm_variant ret = hera->query_fn(call->env, EVM_ADDRESS, arg);
 
       copyAddressToMemory(ret.address, resultOffset);
 
       return Literal();
     }
+
+    if (import->base == Name("getBalance")) {
+      std::cout << "getBalance";
+
+      uint32_t addressOffset = arguments[0].geti32();
+      uint32_t resultOffset = arguments[1].geti32();
+
+      std::cout << addressOffset << " " << resultOffset << "\n";
+
+      union evm_variant arg = { .address = 0 };
+
+      uint32_t i = addressOffset;
+      for (; i < (addressOffset + 20); ++i) {
+        arg.address.bytes[i - addressOffset] = memory.get<uint8_t>(i);	
+      }
+
+      union evm_variant ret = hera->query_fn(call->env, EVM_BALANCE, arg);
+
+      memory.set<struct evm_uint256>(resultOffset, ret.uint256);
+
+      return Literal();
+    } 
 
     if (import->base == Name("getCallDataSize")) {
       std::cout << "calldatasize " << call->input.size() << "\n";

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -55,7 +55,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       evm_uint160be address;
       //TODO: get address of executing account
-      copyAddressToMemory(address, resultOffset);
+      memWrite(resultOffset, address->bytes, 20);
 
       return Literal();
     }
@@ -69,10 +69,10 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       std::cout << addressOffset << " " << resultOffset << "\n";
 
       struct evm_uint160be *address;
-      copyAddressFromMemory(address, addressOffset);
+      memRead(addressOffset, address->bytes, 20);
       struct evm_uint256be *balance;
       hera->get_balance_fn(balance, call->context, address);
-      copy256ToMemory(balance, resultOffset);
+      memWrite(resultOffset, balance->bytes, 32);
 
       return Literal();
     }
@@ -86,7 +86,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       
       struct evm_uint256be *blockhash;
       hera->get_block_hash_fn(blockhash, call->context, number);
-      copy256ToMemory(blockhash, resultOffset);
+      memWrite(resultOffset, blockhash->bytes, 32);
 
       return Literal();
     }

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -53,7 +53,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       std::cout << resultOffset << "\n";
 
-      evm_uint160be address;
+      evm_address address;
       //TODO: get address of executing account
       memWrite(resultOffset, address->bytes, 20);
 
@@ -68,7 +68,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       std::cout << addressOffset << " " << resultOffset << "\n";
 
-      struct evm_uint160be *address;
+      struct evm_address *address;
       memRead(addressOffset, address->bytes, 20);
       struct evm_uint256be *balance;
       hera->get_balance_fn(balance, call->context, address);
@@ -102,7 +102,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       uint32_t resultOffset = arguments[5].geti32();
       uint32_t resultLength = arguments[6].geti32();
 
-      evm_uint160be *dstaddress;
+      evm_address *dstaddress;
       memRead(addressOffset, dstaddress->bytes, 20);
       evm_uint256be *value;
       memRead(valueOffset, value->bytes, 32);

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -103,12 +103,12 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       uint32_t resultLength = arguments[6].geti32();
 
       evm_uint160be *dstaddress;
-      copyAddressFromMemory(address, addressOffset);
+      memRead(addressOffset, dstaddress->bytes, 20);
       evm_uint256be *value;
-      copy256FromMemory(value, valueOffset);
+      memRead(valueOffset, value->bytes, 32);
 
       uint8_t *data = new uint8_t[dataLength];
-      copyBytesFromMemory(dataOffset, data, dataLength);
+      memRead(dataOffset, data, dataLength);
 
       struct evm_message *messagecall;
       messagecall->address = *dstaddress;
@@ -128,7 +128,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       //FIXME: exception type
       if (callResult->output_size > resultLength)
       	throw std::runtime_error("EVM call output length exceeds maximum result length");
-      copyBytesToMemory(resultOffset, callResult->output_data, resultLength);
+      memWrite(resultOffset, callResult->output_data, resultLength);
       
       uint8_t trap_state;
       return Literal((uint8_t)trap_state);

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -37,7 +37,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
     if (import->base == Name("useGas")) {
       std::cout << "usegas ";
 
-      int64_t gas = arguments[0].geti64();
+      uint64_t gas = arguments[0].geti64();
 
       std::cout << gas << "\n";
 
@@ -80,7 +80,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
     if (import->base == Name("getBlockHash")) {
       std::cout << "getBlockHash";
 
-      int64_t number = arguments[0].geti64();
+      uint64_t number = arguments[0].geti64();
       uint32_t resultOffset = arguments[1].geti32();
       std::cout << number << " " << resultOffset << "\n";
       
@@ -91,17 +91,37 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       return Literal();
     }
 
+    if (import->base == Name("call")) {
+      std::cout << "call";
+      
+      uint64_t gas = arguments[0].geti64();
+      uint32_t addressOffset = arguments[1].geti32();
+      uint32_t valueOffset = arguments[2].geti32();
+      uint32_t dataOffset = arguments[3].geti32();
+      uint32_t dataLength = arguments[4].geti32();
+      uint32_t resultOffset = arguments[5].geti32();
+      uint32_t resultLength = arguments[6].geti32();
+
+      evm_uint160be *address;
+      copyAddressFromMemory(address, addressOffset);
+      evm_uint256 *value;
+      copy256FromMemory(value, valueOffset);
+      
+      uint8_t trap_state;
+      return Literal((uint8_t)trap_state);
+    }
+
     if (import->base == Name("getCallDataSize")) {
-      std::cout << "calldatasize " << call->input.size() << "\n";
+      std::cout << "callDataSize " << call->input.size() << "\n";
       return Literal((uint32_t)call->input.size());
     }
 
     if (import->base == Name("callDataCopy")) {
-      std::cout << "calldatacopy ";
+      std::cout << "CallDataCopy ";
 
       uint32_t resultOffset = arguments[0].geti32();
       uint32_t dataOffset = arguments[1].geti32();
-      int32_t length = arguments[2].geti32();
+      uint32_t length = arguments[2].geti32();
 
       std::cout << resultOffset << " " << dataOffset << " " << length << "\n";
 
@@ -114,7 +134,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       std::cout << "return ";
 
       uint32_t offset = arguments[0].geti32();
-      int32_t size = arguments[1].geti32();
+      uint32_t size = arguments[1].geti32();
 
       std::cout << offset << " " << size << "\n";
 

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -53,7 +53,7 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       std::cout << resultOffset << "\n";
 
-      union evm_variant arg = { .address = 0 };
+      union evm_variant arg = { .int64 = 0 };
       union evm_variant ret = hera->query_fn(call->env, EVM_ADDRESS, arg);
 
       copyAddressToMemory(ret.address, resultOffset);
@@ -77,11 +77,26 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       }
 
       union evm_variant ret = hera->query_fn(call->env, EVM_BALANCE, arg);
+      //TODO: write helper for writing uint256 to memory
+      memory.set<struct evm_uint256>(resultOffset, ret.uint256);
+
+      return Literal();
+    }
+
+    if (import->base == Name("getBlockHash")) {
+      std::cout << "getBlockHash";
+
+      uint32_t number = arguments[0].geti32();
+      uint32_t resultOffset = arguments[1].geti32();
+      std::cout << number << " " << resultOffset << "\n";
+      //TODO: do this without a cast 
+      union evm_variant arg = { .int64 = (int64_t)number };
+      union evm_variant ret = hera->query_fn(call->env, EVM_BLOCKHASH, arg);
 
       memory.set<struct evm_uint256>(resultOffset, ret.uint256);
 
       return Literal();
-    } 
+    }
 
     if (import->base == Name("getCallDataSize")) {
       std::cout << "calldatasize " << call->input.size() << "\n";

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -53,10 +53,9 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       std::cout << resultOffset << "\n";
 
-      union evm_variant arg = { .int64 = 0 };
-      union evm_variant ret = hera->query_fn(call->env, EVM_ADDRESS, arg);
-
-      copyAddressToMemory(ret.address, resultOffset);
+      evm_uint160be address;
+      //TODO: address callback fn
+      copyAddressToMemory(address, resultOffset);
 
       return Literal();
     }
@@ -69,16 +68,11 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
 
       std::cout << addressOffset << " " << resultOffset << "\n";
 
-      union evm_variant arg = { .address = 0 };
-
-      uint32_t i = addressOffset;
-      for (; i < (addressOffset + 20); ++i) {
-        arg.address.bytes[i - addressOffset] = memory.get<uint8_t>(i);	
-      }
-
-      union evm_variant ret = hera->query_fn(call->env, EVM_BALANCE, arg);
-      //TODO: write helper for writing uint256 to memory
-      memory.set<struct evm_uint256>(resultOffset, ret.uint256);
+      struct evm_uint160be *address;
+      copyAddressFromMemory(address, addressOffset);
+      struct evm_uint256be *balance;
+      //TODO: balance callback function with context
+      copy256ToMemory(balance, resultOffset);
 
       return Literal();
     }
@@ -89,11 +83,10 @@ Literal EthereumInterface::callImport(Import *import, LiteralList& arguments) {
       uint32_t number = arguments[0].geti32();
       uint32_t resultOffset = arguments[1].geti32();
       std::cout << number << " " << resultOffset << "\n";
-      //TODO: do this without a cast 
-      union evm_variant arg = { .int64 = (int64_t)number };
-      union evm_variant ret = hera->query_fn(call->env, EVM_BLOCKHASH, arg);
-
-      memory.set<struct evm_uint256>(resultOffset, ret.uint256);
+      
+      struct evm_uint256be *blockhash;
+      //TODO: blockhash callback function with context
+      copy256ToMemory(blockhash, resultOffset);
 
       return Literal();
     }

--- a/src/eei.h
+++ b/src/eei.h
@@ -44,7 +44,7 @@ struct EthereumInterface : ShellExternalInterface {
 
 private:
 
-  void takeGas(uint32_t gas)
+  void takeGas(int64_t gas)
   {
       if (gas > call->gas) {
         throw std::runtime_error("Out of gas.");

--- a/src/eei.h
+++ b/src/eei.h
@@ -68,11 +68,28 @@ private:
     }
   }
 
-  void copyAddressToMemory(struct evm_hash160 hash160, uint32_t dstoffset)
+  //TODO: simplify memory helpers to reusable read/write functions like memoryCopy
+  void copyAddressToMemory(struct evm_uint160be address, uint32_t dstoffset)
   {
     for (uint32_t i = 0, j = dstoffset; j < (dstoffset + 20); i++, j++) {
-      memory.set<uint8_t>(j, hash160.bytes[i]);
+      memory.set<uint8_t>(j, address.bytes[i]);
     }
+  }
+
+  void copyAddressFromMemory(struct evm_uint160be *dst, uint32_t offset)
+  {
+     int i = offset;
+     for (; i < (offset + 20); ++i) {
+	dst->bytes[i - offset] = memory.get<uint8_t>(i);
+     }
+  }
+
+  void copy256ToMemory(struct evm_uint256be *balance, uint32_t dstoffset)
+  {
+     int i = dstoffset;
+     for (; i < (dstoffset + 32); ++i) {
+        memory.set<uint8_t>(i, balance->bytes[i - dstoffset]);
+     }
   }
 
 private:

--- a/src/eei.h
+++ b/src/eei.h
@@ -92,6 +92,22 @@ private:
      }
   }
 
+  void memRead(uint32_t offset, uint8_t *dst, size_t length)
+  {
+     uint32_t i;
+     for (i = offset; i < (offset + length); i++) {
+     	*(dst + i - offset) = memory.get<uint8_t>(i);
+     }
+  }
+
+  void memWrite(uint32_t dstoffset, uint8_t *src, size_t length)
+  {
+     uint32_t i;
+     for (i = dstoffset; i < (dstoffset + length); i++) {
+     	memory.set<uint8_t>(i, *(src + i - dstoffset));
+     }
+  }
+
 private:
   Hera *hera;
   HeraCall *call;

--- a/src/eei.h
+++ b/src/eei.h
@@ -44,7 +44,7 @@ struct EthereumInterface : ShellExternalInterface {
 
 private:
 
-  void takeGas(int64_t gas)
+  void takeGas(uint64_t gas)
   {
       if (gas > call->gas) {
         throw std::runtime_error("Out of gas.");
@@ -105,6 +105,14 @@ private:
      uint32_t i;
      for (i = dstoffset; i < (dstoffset + length); i++) {
      	memory.set<uint8_t>(i, *(src + i - dstoffset));
+     }
+  }
+
+  void copy256FromMemory(struct evm_uint256be *dst, uint32_t offset)
+  {
+     int i = offset;
+     for (i; i < (offset + 32); ++i) {
+     	dst->bytes[i - offset] = memory.get<uint8_t>(i);
      }
   }
 

--- a/src/eei.h
+++ b/src/eei.h
@@ -116,21 +116,6 @@ private:
      }
   }
 
-  void copyBytesFromMemory(uint32_t offset, uint8_t *dst, size_t length)  {
-     int i = offset;
-     for (; i < (offset + length); ++i) {
-     	*(dst + (i - offset)) = memory.get<uint8_t>(i);
-     }
-  }
-
-  void copyBytesToMemory(uint32_t dstoffset, uint8_t *data, size_t length)
-  {
-     int i = dstoffset;
-     for (; i < (offset + length); ++i) {
-        memory.set<uint8_t>(i, *(data + i - dstoffset));
-     }
-  }
-
 private:
   Hera *hera;
   HeraCall *call;

--- a/src/eei.h
+++ b/src/eei.h
@@ -111,8 +111,23 @@ private:
   void copy256FromMemory(struct evm_uint256be *dst, uint32_t offset)
   {
      int i = offset;
-     for (i; i < (offset + 32); ++i) {
+     for (; i < (offset + 32); ++i) {
      	dst->bytes[i - offset] = memory.get<uint8_t>(i);
+     }
+  }
+
+  void copyBytesFromMemory(uint32_t offset, uint8_t *dst, size_t length)  {
+     int i = offset;
+     for (; i < (offset + length); ++i) {
+     	*(dst + (i - offset)) = memory.get<uint8_t>(i);
+     }
+  }
+
+  void copyBytesToMemory(uint32_t dstoffset, uint8_t *data, size_t length)
+  {
+     int i = dstoffset;
+     for (; i < (offset + length); ++i) {
+        memory.set<uint8_t>(i, *(data + i - dstoffset));
      }
   }
 

--- a/src/eei.h
+++ b/src/eei.h
@@ -69,14 +69,14 @@ private:
   }
 
   //TODO: simplify memory helpers to reusable read/write functions like memoryCopy
-  void copyAddressToMemory(struct evm_uint160be address, uint32_t dstoffset)
+  void copyAddressToMemory(struct evm_address address, uint32_t dstoffset)
   {
     for (uint32_t i = 0, j = dstoffset; j < (dstoffset + 20); i++, j++) {
       memory.set<uint8_t>(j, address.bytes[i]);
     }
   }
 
-  void copyAddressFromMemory(struct evm_uint160be *dst, uint32_t offset)
+  void copyAddressFromMemory(struct evm_address *dst, uint32_t offset)
   {
      int i = offset;
      for (; i < (offset + 20); ++i) {

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -55,11 +55,9 @@ EXPORT char const* evm_get_info(enum evm_info_key key)
 }
 
 
-EXPORT struct evm_instance* evm_create(evm_query_fn query_fn,
-                                       evm_update_fn update_fn,
-                                       evm_call_fn call_fn)
+EXPORT struct evm_instance* evm_create(struct evm_host host)
 {
-  Hera *hera = new Hera(query_fn, update_fn, call_fn);
+  Hera *hera = new Hera(host);
 
   return reinterpret_cast<evm_instance*>(hera);
 }

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -44,9 +44,10 @@ using namespace HeraVM;
 
 extern "C" {
 
-EXPORT struct evm_instance* evm_create(struct evm_host host)
+EXPORT struct evm_instance* evm_create(void)
 {
-  Hera *hera = new Hera(host);
+  //FIXME: Hera class constructor should have base fns
+  Hera *hera = new Hera();
 
   return reinterpret_cast<evm_instance*>(hera);
 }

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -69,18 +69,18 @@ EXPORT void evm_destroy(struct evm_instance* instance)
 }
 
 EXPORT bool evm_set_option(struct evm_instance* evm,
-                           char const* name,
-                           char const* value)
+                    char const* name,
+                    char const* value)
 {
   return false;
 }
 
 EXPORT struct evm_result evm_execute(struct evm_instance *instance,
-                                     struct evm_context *context,
-                                     enum evm_revision rev,
-				     const struct evm_message *msg,
-                                     uint8_t const* code,
-                                     size_t size)
+                              struct evm_context *context,
+                              enum evm_revision rev,
+			      const struct evm_message *msg,
+                              uint8_t const* code,
+                              size_t code_size)
 {
   auto hera = *reinterpret_cast<Hera*>(instance);
   struct evm_result ret;
@@ -89,15 +89,14 @@ EXPORT struct evm_result evm_execute(struct evm_instance *instance,
 
   std::vector<char> _code(false);
   _code.resize(code_size);
-  std::copy_n(code, size, _code.begin());
-//TODO: adjust for new arg set from evmc
+  std::copy_n(code, code_size, _code.begin());
+
   std::vector<char> _input(false);
-  if (input_size) {
-    _input.resize(input_size);
-    std::copy_n(input, input_size, _input.begin());
+  if (msg->input_size) {
+    _input.resize(msg->input_size);
+    std::copy_n(msg->input, msg->input_size, _input.begin());
   }
-//TODO: adjust for new HeraCall constructor
-  HeraCall *call = new HeraCall(context, _code, gas, _input, value);
+  HeraCall *call = new HeraCall(context, _code, msg->gas, _input, value);
 
   try {
     hera.execute(call);

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -44,17 +44,6 @@ using namespace HeraVM;
 
 extern "C" {
 
-EXPORT char const* evm_get_info(enum evm_info_key key)
-{
-  switch(key) {
-    case EVM_NAME: return "Hera (eWASM)"; break;
-    case EVM_VERSION: return "git"; break;
-  }
-
-  return "";
-}
-
-
 EXPORT struct evm_instance* evm_create(struct evm_host host)
 {
   Hera *hera = new Hera(host);

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -44,10 +44,19 @@ using namespace HeraVM;
 
 extern "C" {
 
-EXPORT struct evm_instance* evm_create(void)
+EXPORT struct evm_instance* evm_create(const int abi_vn,
+                                evm_destroy_fn destroy,
+                                evm_execute_fn execute,
+				evm_get_code_status_fn get_code_status,
+				evm_prepare_code_fn prepare_code,
+				evm_set_option_fn set_option)
 {
-  //FIXME: Hera class constructor should have base fns
-  Hera *hera = new Hera();
+  Hera *hera = new Hera(abi_vn,
+                        destroy,
+			execute,
+			get_code_status,
+			prepare_code,
+			set_option);
 
   return reinterpret_cast<evm_instance*>(hera);
 }

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -75,16 +75,12 @@ EXPORT bool evm_set_option(struct evm_instance* evm,
   return false;
 }
 
-EXPORT struct evm_result evm_execute(struct evm_instance* instance,
-                                     struct evm_env* env,
-                                     enum evm_mode mode,
-                                     struct evm_hash256 code_hash,
+EXPORT struct evm_result evm_execute(struct evm_instance *instance,
+                                     struct evm_context *context,
+                                     enum evm_revision rev,
+				     const struct evm_message *msg,
                                      uint8_t const* code,
-                                     size_t code_size,
-                                     int64_t gas,
-                                     uint8_t const* input,
-                                     size_t input_size,
-                                     struct evm_uint256 value)
+                                     size_t size)
 {
   auto hera = *reinterpret_cast<Hera*>(instance);
   struct evm_result ret;
@@ -93,15 +89,15 @@ EXPORT struct evm_result evm_execute(struct evm_instance* instance,
 
   std::vector<char> _code(false);
   _code.resize(code_size);
-  std::copy_n(code, code_size, _code.begin());
-
+  std::copy_n(code, size, _code.begin());
+//TODO: adjust for new arg set from evmc
   std::vector<char> _input(false);
   if (input_size) {
     _input.resize(input_size);
     std::copy_n(input, input_size, _input.begin());
   }
-
-  HeraCall *call = new HeraCall(env, _code, gas, _input, value);
+//TODO: adjust for new HeraCall constructor
+  HeraCall *call = new HeraCall(context, _code, gas, _input, value);
 
   try {
     hera.execute(call);
@@ -170,7 +166,7 @@ void Hera::execute(HeraCall *call) {
   // passRunner.addDefaultOptimizationPasses();
   // passRunner.run();
 
-  // Interpet
+  // Interpret
   EthereumInterface *interface = new EthereumInterface(this, call);
   ModuleInstance instance(*module, interface);
 

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -96,7 +96,7 @@ EXPORT struct evm_result evm_execute(struct evm_instance *instance,
     _input.resize(msg->input_size);
     std::copy_n(msg->input, msg->input_size, _input.begin());
   }
-  HeraCall *call = new HeraCall(context, _code, msg->gas, _input, value);
+  HeraCall *call = new HeraCall(context, _code, msg->gas, _input);
 
   try {
     hera.execute(call);

--- a/src/hera.h
+++ b/src/hera.h
@@ -51,20 +51,6 @@ public:
 class Hera
 {
 public:
-  /*Hera(struct evm_context *_context)
-  {
-    this->account_exists_fn = _context->fn_table.account_exists;
-    this->get_storage_fn = _context->fn_table.get_storage;  
-    this->set_storage_fn = _context->fn_table.set_storage;
-    this->get_balance_fn = _context->fn_table.get_balance;
-    this->get_code_fn = _context->fn_table.get_code;
-    this->self_destruct_fn = _context->fn_table.selfdestruct;
-    this->call_fn = _context->fn_table.call;  
-    this->get_tx_context_fn = _context->fn_table.get_tx_context;  
-    this->get_block_hash_fn = _context->fn_table.get_block_hash;  
-    this->log_fn = _context->fn_table.log;
-  }*/
-
   Hera(const int abi_vn,
        evm_destroy_fn destroy_fn,
        evm_execute_fn execute_fn,
@@ -89,19 +75,6 @@ public:
   evm_get_code_status_fn get_code_status = nullptr;
   evm_prepare_code_fn prepare_code = nullptr;
   evm_set_option_fn set_option = nullptr;
-
-/*
-  evm_account_exists_fn account_exists_fn = nullptr;
-  evm_get_storage_fn get_storage_fn = nullptr;
-  evm_set_storage_fn set_storage_fn = nullptr;
-  evm_get_balance_fn get_balance_fn = nullptr;
-  evm_get_code_fn get_code_fn = nullptr;
-  evm_selfdestruct_fn self_destruct_fn = nullptr;
-  evm_call_fn call_fn = nullptr;
-  evm_get_tx_context_fn get_tx_context_fn = nullptr;
-  evm_get_block_hash_fn get_block_hash_fn = nullptr;
-  evm_log_fn log_fn = nullptr;
-*/
 };
 
 }

--- a/src/hera.h
+++ b/src/hera.h
@@ -52,25 +52,46 @@ public:
 class Hera
 {
 public:
-  Hera(struct evm_host host)
+  /*Hera(struct evm_context *_context)
   {
-    this->account_exists_fn = host.account_exists;
-    this->get_storage_fn = host.get_storage;  
-    this->set_storage_fn = host.set_storage;
-    this->get_balance_fn = host.get_balance;
-    this->get_code_fn = host.get_code;
-    this->self_destruct_fn = host.selfdestruct;
-    this->call_fn = host.call;  
-    this->get_tx_context_fn = host.get_tx_context;  
-    this->get_block_hash_fn = host.get_block_hash;  
-    this->log_fn = host.log;
-  }
+    this->account_exists_fn = _context->fn_table.account_exists;
+    this->get_storage_fn = _context->fn_table.get_storage;  
+    this->set_storage_fn = _context->fn_table.set_storage;
+    this->get_balance_fn = _context->fn_table.get_balance;
+    this->get_code_fn = _context->fn_table.get_code;
+    this->self_destruct_fn = _context->fn_table.selfdestruct;
+    this->call_fn = _context->fn_table.call;  
+    this->get_tx_context_fn = _context->fn_table.get_tx_context;  
+    this->get_block_hash_fn = _context->fn_table.get_block_hash;  
+    this->log_fn = _context->fn_table.log;
+  }*/
 
-  Hera() {}
+  Hera(const int abi_vn,
+       evm_destroy_fn destroy_fn,
+       evm_execute_fn execute_fn,
+       evm_get_code_status_fn get_code_status_fn,
+       evm_prepare_code_fn prepare_code_fn,
+       evm_set_option_fn set_option_fn) 
+  {
+    this->abi_version = abi_vn;
+    this->destroy = destroy_fn;
+    this->execute = execute_fn;
+    this->get_code_status = get_code_status_fn;
+    this->prepare_code = prepare_code_fn;
+    this->evm_set_option = set_option_fn;
+  }
 
   void execute(HeraCall *call);
 
 public:
+  const int abi_version;
+  evm_destroy_fn destroy = nullptr;
+  evm_execute_fn execute = nullptr;
+  evm_get_code_status_fn get_code_status = nullptr;
+  evm_prepare_code_fn prepare_code = nullptr;
+  evm_set_option_fn set_option = nullptr;
+
+/*
   evm_account_exists_fn account_exists_fn = nullptr;
   evm_get_storage_fn get_storage_fn = nullptr;
   evm_set_storage_fn set_storage_fn = nullptr;
@@ -81,6 +102,7 @@ public:
   evm_get_tx_context_fn get_tx_context_fn = nullptr;
   evm_get_block_hash_fn get_block_hash_fn = nullptr;
   evm_log_fn log_fn = nullptr;
+*/
 };
 
 }

--- a/src/hera.h
+++ b/src/hera.h
@@ -31,13 +31,12 @@ namespace HeraVM {
 class HeraCall
 {
 public:
-  HeraCall(struct evm_context *_context, std::vector<char> _code, int64_t _gas, std::vector<char> _input, struct evm_uint256be _value)
+  HeraCall(struct evm_context *_context, std::vector<char> _code, int64_t _gas, std::vector<char> _input)
   {
     context = _context;
     code = _code;
     gas = _gas;
     input = _input;
-    value = _value;
   }
 
 public:
@@ -46,7 +45,6 @@ public:
   std::vector<char> code;
   int64_t gas;
   std::vector<char> input;
-  struct evm_uint256be value;
 
   std::vector<char> returnValue;
 };
@@ -61,7 +59,7 @@ public:
     this->set_storage_fn = host.set_storage;
     this->get_balance_fn = host.get_balance;
     this->get_code_fn = host.get_code;
-    this->self_destruct_fn = host.self_destruct;
+    this->self_destruct_fn = host.selfdestruct;
     this->call_fn = host.call;  
     this->get_tx_context_fn = host.get_tx_context;  
     this->get_block_hash_fn = host.get_block_hash;  
@@ -78,7 +76,7 @@ public:
   evm_set_storage_fn set_storage_fn = nullptr;
   evm_get_balance_fn get_balance_fn = nullptr;
   evm_get_code_fn get_code_fn = nullptr;
-  evm_self_destruct_fn self_destruct_fn = nullptr;
+  evm_selfdestruct_fn self_destruct_fn = nullptr;
   evm_call_fn call_fn = nullptr;
   evm_get_tx_context_fn get_tx_context_fn = nullptr;
   evm_get_block_hash_fn get_block_hash_fn = nullptr;

--- a/src/hera.h
+++ b/src/hera.h
@@ -31,9 +31,9 @@ namespace HeraVM {
 class HeraCall
 {
 public:
-  HeraCall(struct evm_env *_env, std::vector<char> _code, int64_t _gas, std::vector<char> _input, struct evm_uint256 _value)
+  HeraCall(struct evm_context *_context, std::vector<char> _code, int64_t _gas, std::vector<char> _input, struct evm_uint256be _value)
   {
-    env = _env;
+    context = _context;
     code = _code;
     gas = _gas;
     input = _input;
@@ -41,12 +41,12 @@ public:
   }
 
 public:
-  struct evm_env *env;
+  struct evm_context *context;
 
   std::vector<char> code;
   int64_t gas;
   std::vector<char> input;
-  struct evm_uint256 value;
+  struct evm_uint256be value;
 
   std::vector<char> returnValue;
 };
@@ -54,41 +54,18 @@ public:
 class Hera
 {
 public:
-  Hera(evm_account_exists_fn account_exists_fn,
-  	evm_get_storage_fn get_storage_fn,
-	evm_set_storage_fn set_storage_fn,
-	evm_get_balance_fn get_balance_fn,
-	evm_get_code_fn get_code_fn,
-	evm_self_destruct_fn self_destruct_fn,
-	evm_call_fn call_fn
-	evm_get_tx_context_fn get_tx_context_fn,
-	evm_get_block_hash_fn get_block_hash_fn,
-	evm_log_fn log_fn)
-  {
-    this->account_exists_fn = account_exists_fn;
-    this->get_storage_fn = get_storage_fn;  
-    this->set_storage_fn = set_storage_fn;
-    this->get_balance_fn = get_balance_fn;
-    this->get_code_fn = get_code_fn;
-    this->self_destruct_fn = self_destruct_fn;
-    this->call_fn = call_fn;  
-    this->get_tx_context_fn = get_tx_context_fn;  
-    this->get_block_hash_fn = get_block_hash_fn;  
-    this->log_fn = log_fn;
-  }
-
   Hera(struct evm_host host)
   {
-    this->host.account_exists_fn = host.account_exists_fn;
-    this->host.get_storage_fn = host.get_storage_fn;  
-    this->host.set_storage_fn = host.set_storage_fn;
-    this->host.get_balance_fn = host.get_balance_fn;
-    this->host.get_code_fn = host.get_code_fn;
-    this->host.self_destruct_fn = host.self_destruct_fn;
-    this->host.call_fn = host.call_fn;  
-    this->host.get_tx_context_fn = host.get_tx_context_fn;  
-    this->host.get_block_hash_fn = host.get_block_hash_fn;  
-    this->host.log_fn = host.log_fn;
+    this->account_exists_fn = host.account_exists;
+    this->get_storage_fn = host.get_storage;  
+    this->set_storage_fn = host.set_storage;
+    this->get_balance_fn = host.get_balance;
+    this->get_code_fn = host.get_code;
+    this->self_destruct_fn = host.self_destruct;
+    this->call_fn = host.call;  
+    this->get_tx_context_fn = host.get_tx_context;  
+    this->get_block_hash_fn = host.get_block_hash;  
+    this->log_fn = host.log;
   }
 
   Hera() {}
@@ -106,9 +83,6 @@ public:
   evm_get_tx_context_fn get_tx_context_fn = nullptr;
   evm_get_block_hash_fn get_block_hash_fn = nullptr;
   evm_log_fn log_fn = nullptr;
-
-public:
-  struct evm_host host = nullptr;
 };
 
 }

--- a/src/hera.h
+++ b/src/hera.h
@@ -54,11 +54,41 @@ public:
 class Hera
 {
 public:
-  Hera(evm_query_fn query_fn, evm_update_fn update_fn, evm_call_fn call_fn)
+  Hera(evm_account_exists_fn account_exists_fn,
+  	evm_get_storage_fn get_storage_fn,
+	evm_set_storage_fn set_storage_fn,
+	evm_get_balance_fn get_balance_fn,
+	evm_get_code_fn get_code_fn,
+	evm_self_destruct_fn self_destruct_fn,
+	evm_call_fn call_fn
+	evm_get_tx_context_fn get_tx_context_fn,
+	evm_get_block_hash_fn get_block_hash_fn,
+	evm_log_fn log_fn)
   {
-    this->query_fn = query_fn;
-    this->update_fn = update_fn;
-    this->call_fn = call_fn;
+    this->account_exists_fn = account_exists_fn;
+    this->get_storage_fn = get_storage_fn;  
+    this->set_storage_fn = set_storage_fn;
+    this->get_balance_fn = get_balance_fn;
+    this->get_code_fn = get_code_fn;
+    this->self_destruct_fn = self_destruct_fn;
+    this->call_fn = call_fn;  
+    this->get_tx_context_fn = get_tx_context_fn;  
+    this->get_block_hash_fn = get_block_hash_fn;  
+    this->log_fn = log_fn;
+  }
+
+  Hera(struct evm_host host)
+  {
+    this->host.account_exists_fn = host.account_exists_fn;
+    this->host.get_storage_fn = host.get_storage_fn;  
+    this->host.set_storage_fn = host.set_storage_fn;
+    this->host.get_balance_fn = host.get_balance_fn;
+    this->host.get_code_fn = host.get_code_fn;
+    this->host.self_destruct_fn = host.self_destruct_fn;
+    this->host.call_fn = host.call_fn;  
+    this->host.get_tx_context_fn = host.get_tx_context_fn;  
+    this->host.get_block_hash_fn = host.get_block_hash_fn;  
+    this->host.log_fn = host.log_fn;
   }
 
   Hera() {}
@@ -66,9 +96,19 @@ public:
   void execute(HeraCall *call);
 
 public:
-  evm_query_fn query_fn = nullptr;
-  evm_update_fn update_fn = nullptr;
+  evm_account_exists_fn account_exists_fn = nullptr;
+  evm_get_storage_fn get_storage_fn = nullptr;
+  evm_set_storage_fn set_storage_fn = nullptr;
+  evm_get_balance_fn get_balance_fn = nullptr;
+  evm_get_code_fn get_code_fn = nullptr;
+  evm_self_destruct_fn self_destruct_fn = nullptr;
   evm_call_fn call_fn = nullptr;
+  evm_get_tx_context_fn get_tx_context_fn = nullptr;
+  evm_get_block_hash_fn get_block_hash_fn = nullptr;
+  evm_log_fn log_fn = nullptr;
+
+public:
+  struct evm_host host = nullptr;
 };
 
 }

--- a/src/hera.h
+++ b/src/hera.h
@@ -41,7 +41,6 @@ public:
 
 public:
   struct evm_context *context;
-
   std::vector<char> code;
   int64_t gas;
   std::vector<char> input;


### PR DESCRIPTION
- Updated for latest EVM-C API
- Updated Hera and HeraCall class constructors
- Implemented getBlockHash, getBalance from EEI specification
- Removed evm_get_info as it is not implemented in the latest EVM-C
- Numerous helper functions for memory read/write
- Configured compiler to generate fully position independent code, useful for shared libs