### PR TITLE
fix isZeroUint256 helper function

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -775,8 +775,8 @@ namespace HeraVM {
   {
     for (unsigned i = 0; i < 32; i++) {
       if (value.bytes[i] != 0)
-        return true;
+        return false;
     }
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
Returns false when an element different than zero is found.