### PR TITLE
Fix issue with EVM bytecode mangling

### DIFF
--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -153,7 +153,7 @@ vector<uint8_t> evm2wasm_js(vector<uint8_t> const& input) {
   ofstream os;
   os.open(fileEVM);
   // print as a hex sting
-  os << hex;
+  os << setfill('0') << setw(2) << hex;
   for (uint8_t byte: input)
     os << static_cast<int>(byte);
   os.close();


### PR DESCRIPTION
When running transcompiled EVM code (from evm2wasm.js), individual bytes are not correctly padded when storing to a temp file before transcompilation.  The result is that the bytecode is mangled.

This PR fixes the issue.