### PR TITLE
Enable evm2wasm's evm trace output via CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently it uses [Binaryen](https://github.com/webassembly/binaryen)'s interpre
 - `-DHERA_DEBUGGING=ON` will turn on debugging features and messages
 - `-DHERA_METERING_CONTRACT=ON` will pass contract creation data through the metering contract residing at 0x00..0a
 - `-DHERA_EVM2WASM=ON` will use the evm2wasm contract translate EVM bytecode (through the contract residing at 0x00..0b)
+- `-DHERA_EVM2WASM_EVM_TRACE=ON` will output a trace step for each transpiled EVM opcode
 
 ## Runtime options
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,11 @@ if(HERA_EVM2WASM)
   target_compile_definitions(hera PRIVATE HERA_EVM2WASM=1)
 endif()
 
+option(HERA_EVM2WASM_EVM_TRACE "Display trace steps for transpiled EVM opcodes (Better phrasing here?)" ON)
+if(HERA_EVM2WASM_EVM_TRACE)
+  target_compile_definitions(hera PRIVATE HERA_EVM2WASM_EVM_TRACE=1)
+endif()
+
 target_include_directories(hera PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${evm_include_dir})
 target_link_libraries(hera PRIVATE binaryen::binaryen Threads::Threads)
 if(NOT WIN32)

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -159,6 +159,10 @@ vector<uint8_t> evm2wasm_js(vector<uint8_t> const& input) {
   os.close();
 
   string cmd = string("evm2wasm.js ") + "-e " + fileEVM + " -o " + fileWASM;
+#if HERA_EVM2WASM_EVM_TRACE
+  cmd += " --trace";
+#endif
+
   int ret = system(cmd.data());
   unlink(fileEVM.data());
 


### PR DESCRIPTION
It occurs to me that we should be doing this at runtime.. Leaving this here anyways.