### PR TITLE
mktemp null-terminator fix and evm2wasm.js debug prints

### DIFF
--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -145,6 +145,10 @@ string mktemp_string(string pattern) {
 }
 
 vector<uint8_t> evm2wasm_js(vector<uint8_t> const& input, bool evmTrace) {
+#if HERA_DEBUGGING
+  cerr << "Calling evm2wasm.js (input " << input.size() << " bytes)..." << endl;
+#endif
+
   string fileEVM = mktemp_string("/tmp/hera.evm2wasm.evm.XXXXXX");
   string fileWASM = mktemp_string("/tmp/hera.evm2wasm.wasm.XXXXXX");
 
@@ -163,10 +167,18 @@ vector<uint8_t> evm2wasm_js(vector<uint8_t> const& input, bool evmTrace) {
   if (evmTrace)
     cmd += " --trace";
 
+#if HERA_DEBUGGING
+  cerr << "(Calling evm2wasm.js with command: " << cmd << ")" << endl;
+#endif
+
   int ret = system(cmd.data());
   unlink(fileEVM.data());
 
   if (ret != 0) {
+#if HERA_DEBUGGING
+    cerr << "evm2wasm.js failed" << endl;
+#endif
+
     unlink(fileWASM.data());
     return vector<uint8_t>();
   }
@@ -176,6 +188,10 @@ vector<uint8_t> evm2wasm_js(vector<uint8_t> const& input, bool evmTrace) {
                  istreambuf_iterator<char>());
 
   unlink(fileWASM.data());
+
+#if HERA_DEBUGGING
+  cerr << "evm2wasm.js done (output " << str.length() << " bytes)" << endl;
+#endif
 
   return vector<uint8_t>(str.begin(), str.end());
 }

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -137,11 +137,11 @@ vector<uint8_t> sentinel(evm_context* context, vector<uint8_t> const& input)
 // NOTE: assumes that pattern doesn't contain any formatting characters (e.g. %)
 string mktemp_string(string pattern) {
   const unsigned long len = pattern.size();
-  char tmp[len];
-  strncpy(tmp, pattern.data(), len);
+  char tmp[len + 1];
+  strncpy(tmp, pattern.data());
   if (!mktemp(tmp))
      return string();
-  return string(tmp, len);
+  return string(tmp, strlen(tmp));
 }
 
 vector<uint8_t> evm2wasm_js(vector<uint8_t> const& input, bool evmTrace) {

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -139,7 +139,7 @@ string mktemp_string(string pattern) {
   const unsigned long len = pattern.size();
   char tmp[len + 1];
   strncpy(tmp, pattern.data());
-  if (!mktemp(tmp))
+  if (!mktemp(tmp) || (tmp[0] == 0))
      return string();
   return string(tmp, strlen(tmp));
 }


### PR DESCRIPTION
When the char array passed to `mktemp()` is missing a null-terminator, it fails in some environments (on circleCI servers).

replaces https://github.com/ewasm/hera/pull/175