### PR TITLE
Fix missing array import

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <stdexcept>
+#include <array>
 #include "eei.h"
 
 using namespace std;


### PR DESCRIPTION
Likely caused by
https://github.com/ewasm/hera/commit/f16e8ed90a404579a86a1e07f2ec1aff43c826a0.
Per @chfast: I think it was my change, but Linux has different C++
standard lib and array is included by some other header.