### PR TITLE
 loadUint128 to properly write into the right part of evmc_uint256be

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -860,7 +860,7 @@ string toHex(evmc_uint256be const& value) {
   evmc_uint256be EthereumInterface::loadUint128(uint32_t srcOffset)
   {
     evmc_uint256be dst = {};
-    loadMemory(srcOffset, dst.bytes, 16);
+    loadMemory(srcOffset, dst.bytes + 16, 16);
     return dst;
   }
 


### PR DESCRIPTION
They should be loaded into the second half of the `evmc_uint256be`.