### PR TITLE
Remove obsolete metering option from cmake and circleci

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Currently it uses [Binaryen](https://github.com/webassembly/binaryen)'s interpre
 ## Build options
 
 - `-DHERA_DEBUGGING=ON` will turn on debugging features and messages
-- `-DHERA_METERING_CONTRACT=ON` will pass contract creation data through the metering contract residing at 0x00..0a
 - `-DHERA_EVM2WASM=ON` will use the evm2wasm contract translate EVM bytecode (through the contract residing at 0x00..0b)
 
 ## Runtime options

--- a/circle.yml
+++ b/circle.yml
@@ -162,30 +162,6 @@ jobs:
       - CC:  clang
       - GENERATOR: Ninja
       - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DHERA_DEBUGGING=on -DHERA_EVM2WASM=on -DHERA_METERING_CONTRACT=on
-    docker:
-      - image: ethereum/cpp-build-env
-    steps: *linux-steps
-
-  linux-clang-metering:
-    environment:
-      - BUILD_TYPE: Release
-      - CXX: clang++
-      - CC:  clang
-      - GENERATOR: Ninja
-      - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DHERA_DEBUGGING=off -DHERA_METERING_CONTRACT=on
-    docker:
-      - image: ethereum/cpp-build-env
-    steps: *linux-steps
-
-  linux-clang-metering:
-    environment:
-      - BUILD_TYPE: Release
-      - CXX: clang++
-      - CC:  clang
-      - GENERATOR: Ninja
-      - BUILD_PARALLEL_JOBS: 4
       - CMAKE_OPTIONS: -DHERA_DEBUGGING=on -DHERA_EVM2WASM=on
     docker:
       - image: ethereum/cpp-build-env
@@ -210,7 +186,7 @@ jobs:
       - CC:  gcc
       - GENERATOR: Unix Makefiles
       - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DHERA_DEBUGGING=ON -DHERA_EVM2WASM=on -DHERA_METERING_CONTRACT=on
+      - CMAKE_OPTIONS: -DHERA_DEBUGGING=ON -DHERA_EVM2WASM=on
     docker:
       - image: ethereum/cpp-build-env
     steps: *linux-steps
@@ -222,6 +198,5 @@ workflows:
       - linux-clang
       - linux-gcc-debug
       - linux-clang-evm2wasm
-      - linux-clang-metering
       - linux-gcc-all-options
       - ewasm-tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,11 +14,6 @@ if(HERA_DEBUGGING)
   target_compile_definitions(hera PRIVATE HERA_DEBUGGING=1)
 endif()
 
-option(HERA_METERING_CONTRACT "Run metering through the metering contract" OFF)
-if(HERA_METERING_CONTRACT)
-  target_compile_definitions(hera PRIVATE HERA_METERING_CONTRACT=1)
-endif()
-
 option(HERA_EVM2WASM "Build with evm2wasm auto-translation" OFF)
 if(HERA_EVM2WASM)
   target_compile_definitions(hera PRIVATE HERA_EVM2WASM=1)


### PR DESCRIPTION
Missed in #194.