### PR TITLE
revert internal failure to EVMC_FAILURE.

### DIFF
--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -373,7 +373,7 @@ evmc_result hera_execute(
     cerr << e.what() << endl;
 #endif
   } catch (InternalErrorException const& e) {
-    ret.status_code = EVMC_INTERNAL_ERROR;
+    ret.status_code = EVMC_FAILURE;
 #if HERA_DEBUGGING
     cerr << "InternalError: " << e.what() << endl;
 #endif


### PR DESCRIPTION
@cdetrio and I found that the evm2wasm stack tests were failing because of this line.  This reverts the part of the change in https://github.com/ewasm/hera/pull/215 to fix the issue.