### PR TITLE
Memory load/store:  bytes that are out of bounds should be written/read as 0

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -847,7 +847,6 @@ string toHex(evmc_uint256be const& value) {
   void EthereumInterface::loadMemory(uint32_t srcOffset, uint8_t *dst, size_t length)
   {
     ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
-    // int oob_source = (srcOffset + length)
 
     if (!length)
       HERA_DEBUG << "Zero-length memory load from offset 0x" << hex << srcOffset << dec << "\n";
@@ -885,8 +884,6 @@ string toHex(evmc_uint256be const& value) {
 
   void EthereumInterface::storeMemory(vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length)
   {
-    //ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
-    //ensureCondition(src.size() >= (srcOffset + length), InvalidMemoryAccess, "Out of bounds (source) memory copy.");
     ensureCondition((dstOffset + length) >= dstOffset, InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
     ensureCondition(memory.size() >= (dstOffset + length), InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
 
@@ -901,14 +898,9 @@ string toHex(evmc_uint256be const& value) {
       nonZeroFill = src.size() > srcOffset ? src.size() - srcOffset : 0;
     }
 
-    cout << "src offset " << srcOffset << endl << "dst offset" << dstOffset << endl << "length " << length << endl;
-    cout << "zero fill: " << zeroFill << endl << "non-zero fill: " << nonZeroFill << endl << "dst offset: " << dstOffset << endl << length;
-
     for (long unsigned int i = 0; i < nonZeroFill; i++) {
       memory.set<uint8_t>(dstOffset + i, src[srcOffset + i]);
     }
-
-    cout << "foobar\n";
 
     for (long unsigned int i = nonZeroFill; i < nonZeroFill + zeroFill; i++) {
       memory.set<uint8_t>(dstOffset + i, 0);

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -846,7 +846,8 @@ string toHex(evmc_uint256be const& value) {
 
   void EthereumInterface::loadMemory(uint32_t srcOffset, uint8_t *dst, size_t length)
   {
-    ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
+    // ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
+    int oob_source = (srcOffset + length)
 
     if (!length)
       HERA_DEBUG << "Zero-length memory load from offset 0x" << hex << srcOffset << dec << "\n";
@@ -885,15 +886,26 @@ string toHex(evmc_uint256be const& value) {
   void EthereumInterface::storeMemory(vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length)
   {
     ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
-    ensureCondition(src.size() >= (srcOffset + length), InvalidMemoryAccess, "Out of bounds (source) memory copy.");
+    //ensureCondition(src.size() >= (srcOffset + length), InvalidMemoryAccess, "Out of bounds (source) memory copy.");
     ensureCondition((dstOffset + length) >= dstOffset, InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
     ensureCondition(memory.size() >= (dstOffset + length), InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
 
     if (!length)
       HERA_DEBUG << "Zero-length memory store to offset 0x" << hex << dstOffset << dec << "\n";
 
-    for (uint32_t i = 0; i < length; i++) {
+    uint32_t zeroFill = 0;
+    uint32_t nonZerofill = length;
+    if (src.size() <= (srcOffset + length)) {
+      zeroFill = (srcOffset + length) - src.size()
+      nonZerofill = src.size() - srcOffset;
+    }
+
+    for (uint32_t i = 0; i < nonZeroFill; i++) {
       memory.set<uint8_t>(dstOffset + i, src[srcOffset + i]);
+    }
+
+    for (uint32_t i = nonZeroFill; i < zeroFill; i++) {
+      memory.set<uint8_t>(dstOffset + i, 0);
     }
   }
 

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -846,8 +846,8 @@ string toHex(evmc_uint256be const& value) {
 
   void EthereumInterface::loadMemory(uint32_t srcOffset, uint8_t *dst, size_t length)
   {
-    // ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
-    int oob_source = (srcOffset + length)
+    ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
+    // int oob_source = (srcOffset + length)
 
     if (!length)
       HERA_DEBUG << "Zero-length memory load from offset 0x" << hex << srcOffset << dec << "\n";
@@ -885,7 +885,7 @@ string toHex(evmc_uint256be const& value) {
 
   void EthereumInterface::storeMemory(vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length)
   {
-    ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
+    //ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
     //ensureCondition(src.size() >= (srcOffset + length), InvalidMemoryAccess, "Out of bounds (source) memory copy.");
     ensureCondition((dstOffset + length) >= dstOffset, InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
     ensureCondition(memory.size() >= (dstOffset + length), InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
@@ -893,18 +893,24 @@ string toHex(evmc_uint256be const& value) {
     if (!length)
       HERA_DEBUG << "Zero-length memory store to offset 0x" << hex << dstOffset << dec << "\n";
 
-    uint32_t zeroFill = 0;
-    uint32_t nonZerofill = length;
-    if (src.size() <= (srcOffset + length)) {
-      zeroFill = (srcOffset + length) - src.size()
-      nonZerofill = src.size() - srcOffset;
+    long unsigned int zeroFill = 0;
+    long unsigned int nonZeroFill = length;
+
+    if (srcOffset + length > src.size()) {
+      zeroFill = (srcOffset + length) - src.size();
+      nonZeroFill = src.size() > srcOffset ? src.size() - srcOffset : 0;
     }
 
-    for (uint32_t i = 0; i < nonZeroFill; i++) {
+    cout << "src offset " << srcOffset << endl << "dst offset" << dstOffset << endl << "length " << length << endl;
+    cout << "zero fill: " << zeroFill << endl << "non-zero fill: " << nonZeroFill << endl << "dst offset: " << dstOffset << endl << length;
+
+    for (long unsigned int i = 0; i < nonZeroFill; i++) {
       memory.set<uint8_t>(dstOffset + i, src[srcOffset + i]);
     }
 
-    for (uint32_t i = nonZeroFill; i < zeroFill; i++) {
+    cout << "foobar\n";
+
+    for (long unsigned int i = nonZeroFill; i < nonZeroFill + zeroFill; i++) {
       memory.set<uint8_t>(dstOffset + i, 0);
     }
   }


### PR DESCRIPTION
**WIP**

Fixes the test case `randomStatetest283`.

Fixes https://github.com/ewasm/hera/issues/221