### PR TITLE
Use int128 compiler extension for ensureSenderBalance

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -978,11 +978,11 @@ inline int64_t maxCallGas(int64_t gas) {
     ensureCondition(safeLoadUint128(balance) >= safeLoadUint128(value), OutOfGasException, "Out of gas.");
   }
 
-  uint64_t EthereumInterface::safeLoadUint128(evmc_uint256be const& value)
+  unsigned __int128 EthereumInterface::safeLoadUint128(evmc_uint256be const& value)
   {
     // TODO: use a specific error code here?
     ensureCondition(!exceedsUint128(value), OutOfGasException, "Value exceeds 128 bits.");
-    uint64_t ret = 0;
+    unsigned __int128 ret = 0;
     for (unsigned i = 16; i < 32; i++) {
       ret <<= 8;
       ret |= value.bytes[i];

--- a/src/eei.h
+++ b/src/eei.h
@@ -87,7 +87,7 @@ private:
 
   void ensureSenderBalance(evmc_uint256be const& value);
 
-  static uint64_t safeLoadUint128(evmc_uint256be const& value);
+  static unsigned __int128 safeLoadUint128(evmc_uint256be const& value);
 
   /* Checks if host supplied 256 bit value exceeds UINT64_MAX */
   static bool exceedsUint64(evmc_uint256be const& value);


### PR DESCRIPTION
portability of this fix requires investigation

Closes #245. Fixes #190.