### PR TITLE
Fix gas related to CREATE

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -814,6 +814,9 @@ inline int64_t maxCallGas(int64_t gas) {
 
       context->fn_table->call(&create_result, context, &create_message);
 
+      /* Return unspent gas */
+      result.gasLeft += create_result.gas_left;
+
       if (create_result.status_code == EVMC_SUCCESS) {
         storeUint160(create_result.create_address, resultOffset);
         lastReturnData.clear();

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -801,15 +801,17 @@ inline int64_t maxCallGas(int64_t gas) {
       }
 
       create_message.code_hash = {};
-      create_message.gas = result.gasLeft - (result.gasLeft / 64);
       create_message.depth = msg.depth + 1;
       create_message.kind = EVMC_CREATE;
       create_message.flags = 0;
 
       evmc_result create_result;
 
-      takeInterfaceGas(create_message.gas);
       takeInterfaceGas(GasSchedule::create);
+
+      create_message.gas = maxCallGas(result.gasLeft);
+      takeInterfaceGas(create_message.gas);
+
       context->fn_table->call(&create_result, context, &create_message);
 
       if (create_result.status_code == EVMC_SUCCESS) {


### PR DESCRIPTION
Requires https://github.com/ewasm/tests/pull/44

Take base gas before doing 63/64 calc and refund remaining gas after call.
Also includes a bunch more gas-related debug output and a new debug flag to keep evm2wasm output files around for debugging.