### PR TITLE
Fix gas semantics for CALL and CALLCODE

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -727,15 +727,16 @@ inline int64_t maxCallGas(int64_t gas) {
           extra_gas += GasSchedule::callNewAccount;
       }
 
-      // this check is in EIP150 but not in the YellowPaper
+      // This check is in EIP150 but not in the YellowPaper
       takeInterfaceGas(extra_gas);
 
-      // retain one 64th gas (EIP150)
+      // This is the gas we are forwarding to the callee.
+      // Retain one 64th of it as per EIP150
       gas = std::min(gas, maxCallGas(result.gasLeft));
 
       takeInterfaceGas(gas);
 
-      // add gas stipend for value transfers
+      // Add gas stipend for value transfers
       if (!isZeroUint256(call_message.value))
         gas += GasSchedule::valueStipend;
 

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -677,8 +677,6 @@ inline int64_t maxCallGas(int64_t gas) {
         if (import->base == Name("call") && !isZeroUint256(call_message.value)) {
           ensureCondition(!(msg.flags & EVMC_STATIC), StaticModeViolation, "call");
         }
-
-        ensureSenderBalance(call_message.value);
       } else {
         valueOffset = 0;
         dataOffset = arguments[2].geti32();
@@ -742,6 +740,9 @@ inline int64_t maxCallGas(int64_t gas) {
         gas += GasSchedule::valueStipend;
 
       call_message.gas = gas;
+
+      if (import->base == Name("call") || import->base == Name("callCode"))
+        ensureSenderBalance(call_message.value);
 
       context->fn_table->call(&call_result, context, &call_message);
 


### PR DESCRIPTION
If there is insufficient gas for the value being sent with the CALL,
rather than throwing an OOG exception, the operation should just fail.

Fixes an issue detected in test GeneralStateTests/stCallCreateCallCodeTest/callWithHighValue