### PR TITLE
Fix OOB memcopy behavior to match EVM behavior

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -934,7 +934,6 @@ inline int64_t maxCallGas(int64_t gas) {
   void EthereumInterface::storeMemoryZeroPad(vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length)
   {
     ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
-    /* ensureCondition(src.size() >= (srcOffset + length), InvalidMemoryAccess, "Out of bounds (source) memory copy."); */
     ensureCondition((dstOffset + length) >= dstOffset, InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
     ensureCondition(memory.size() >= (dstOffset + length), InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
 

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -359,7 +359,7 @@ inline int64_t maxCallGas(int64_t gas) {
         "Gas charge overflow"
       );
       takeInterfaceGas(GasSchedule::verylow + GasSchedule::copy * ((uint64_t(length) + 31) / 32));
-      storeMemory(code, codeOffset, resultOffset, length);
+      storeMemoryZeroPad(code, codeOffset, resultOffset, length);
 
       return Literal();
     }
@@ -928,6 +928,34 @@ inline int64_t maxCallGas(int64_t gas) {
 
     for (uint32_t i = 0; i < length; i++) {
       memory.set<uint8_t>(dstOffset + i, src[srcOffset + i]);
+    }
+  }
+
+  void EthereumInterface::storeMemoryZeroPad(vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length)
+  {
+    ensureCondition((srcOffset + length) >= srcOffset, InvalidMemoryAccess, "Out of bounds (source) memory copy.");
+    /* ensureCondition(src.size() >= (srcOffset + length), InvalidMemoryAccess, "Out of bounds (source) memory copy."); */
+    ensureCondition((dstOffset + length) >= dstOffset, InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
+    ensureCondition(memory.size() >= (dstOffset + length), InvalidMemoryAccess, "Out of bounds (destination) memory copy.");
+
+    uint32_t origLength = length;
+    uint32_t zeroFill = 0;
+    uint32_t srcSize = static_cast<uint32_t>(src.size());
+    if ((srcOffset + length) > src.size()) {
+      HERA_DEBUG << "Out of bounds (source) memory copy, zero-padding result" << endl;
+      length = srcSize > srcOffset ? srcSize - srcOffset : 0;
+      zeroFill = origLength - length;
+    }
+
+    if (!length)
+      HERA_DEBUG << "Zero-length memory store to offset 0x" << hex << dstOffset << dec << "\n";
+
+    for (uint32_t i = 0; i < length; i++) {
+      memory.set<uint8_t>(dstOffset + i, src[srcOffset + i]);
+    }
+
+    for (uint32_t i = 0; i < zeroFill; i++) {
+      memory.set<uint8_t>(dstOffset + length + i, 0);
     }
   }
 

--- a/src/eei.h
+++ b/src/eei.h
@@ -77,6 +77,7 @@ private:
   void loadMemory(uint32_t srcOffset, std::vector<uint8_t> & dst, size_t length);
   void storeMemory(const uint8_t *src, uint32_t dstOffset, uint32_t length);
   void storeMemory(std::vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length);
+  void storeMemoryZeroPad(std::vector<uint8_t> const& src, uint32_t srcOffset, uint32_t dstOffset, uint32_t length);
 
   evmc_uint256be loadUint256(uint32_t srcOffset);
   void storeUint256(evmc_uint256be const& src, uint32_t dstOffset);


### PR DESCRIPTION
Replaces #222.
Required by https://github.com/ewasm/tests/pull/52.
Cf. https://github.com/ewasm/tests/issues/34.

Per https://github.com/ewasm/tests/issues/34, codecopy and extcodecopy do not
trap on OOB memcopy, only returndatacopy. The first two zero-pad the result.