### PR TITLE
 CMake: Add option to build with WAVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ project(hera)
 
 include(ProjectBinaryen)
 
+option(HERA_WAVM "Build with WAVM" OFF)
+if (HERA_WAVM)
+    include(ProjectWAVM)
+endif()
+
 add_subdirectory(evmc)
 add_subdirectory(evm2wasm)
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Currently it uses [Binaryen](https://github.com/webassembly/binaryen)'s interpre
 - `-DHERA_DEBUGGING=ON` will turn on debugging features and messages
 - `-DBUILD_SHARED_LIBS=ON` is a standard CMake option to build libraries as shared. This will build Hera shared library that can be then dynamically loaded by EVMC compatible Clients (e.g. `eth` from [cpp-ethereum]).
 
+### WAVM support
+
+*Unfinished support, work in progress.*
+
+- `-DHERA_WAVM=ON` will request the compilation of wavm support
+- `-DLLVM_DIR=...` one will need to specify the path to LLVM's CMake file. In most installations this has to be within the `lib/cmake/llvm` directory, such as `/usr/local/Cellar/llvm/6.0.1/lib/cmake/llvm` on Homebrew.
+
 ## Runtime options
 
 These are to be used via EVM-C `set_option`:

--- a/circle.yml
+++ b/circle.yml
@@ -201,9 +201,9 @@ jobs:
       - CC:  clang
       - GENERATOR: Ninja
       - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF
+      - CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF -DHERA_WAVM=ON
     docker:
-      - image: ethereum/cpp-build-env
+      - image: ethereum/cpp-build-env:3
     steps:
       - checkout
       - *update-submodules
@@ -247,7 +247,7 @@ jobs:
       - CC:  gcc
       - GENERATOR: Unix Makefiles
       - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DHERA_DEBUGGING=ON
+      - CMAKE_OPTIONS: -DHERA_DEBUGGING=ON -DHERA_WAVM=ON
     docker:
       - image: ethereum/cpp-build-env
     steps:

--- a/cmake/ProjectWAVM.cmake
+++ b/cmake/ProjectWAVM.cmake
@@ -1,0 +1,60 @@
+if(ProjectWAVMIncluded)
+    return()
+endif()
+set(ProjectWAVMIncluded TRUE)
+
+include(ExternalProject)
+
+find_package(LLVM 6.0 REQUIRED CONFIG)
+message(STATUS "LLVM: ${LLVM_DIR}")
+llvm_map_components_to_libnames(llvm_libs support core passes mcjit native DebugInfoDWARF)
+
+set(prefix ${CMAKE_BINARY_DIR}/deps)
+set(source_dir ${prefix}/src/wavm)
+set(binary_dir ${prefix}/src/wavm-build)
+set(include_dir ${source_dir}/Include)
+
+set(runtime_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Runtime${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(platform_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Platform${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(wasm_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}WASM${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(ir_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}IR${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(logging_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Logging${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(unwind_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}WAVMUnwind${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+set(other_libraries ${platform_library} ${wasm_library} ${ir_library} ${logging_library} ${unwind_library})
+
+ExternalProject_Add(wavm
+    PREFIX ${prefix}
+    DOWNLOAD_NAME wavm-a0baaec170b55cc60cfe6bcc6b36add953a065d8.tar.gz
+    DOWNLOAD_DIR ${prefix}/downloads
+    SOURCE_DIR ${source_dir}
+    BINARY_DIR ${binary_dir}
+    URL https://github.com/AndrewScheidecker/WAVM/archive/a0baaec170b55cc60cfe6bcc6b36add953a065d8.tar.gz
+    URL_HASH SHA256=da184e2c077e257dea82c13b2e5ae1fc03d1dc306a1c9a6f84838cff7390b75a
+    PATCH_COMMAND sh ${CMAKE_CURRENT_LIST_DIR}/patch_wavm.sh
+    CMAKE_ARGS
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_BUILD_TYPE=Release
+    -DLLVM_DIR=${LLVM_DIR}
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DCMAKE_CXX_FLAGS=-Wno-error
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS ${runtime_library} ${other_libraries}
+)
+
+file(MAKE_DIRECTORY ${include_dir})  # Must exist.
+
+
+add_library(wavm::wavm STATIC IMPORTED)
+set_target_properties(
+    wavm::wavm
+    PROPERTIES
+    IMPORTED_CONFIGURATIONS Release
+    IMPORTED_LOCATION_RELEASE ${runtime_library}
+    INTERFACE_INCLUDE_DIRECTORIES ${include_dir}
+    INTERFACE_LINK_LIBRARIES "${other_libraries};${llvm_libs}"
+)
+
+add_dependencies(wavm::wavm wavm)

--- a/cmake/patch_wavm.sh
+++ b/cmake/patch_wavm.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -iE 's/SHARED//' CMakeLists.txt
+sed -iE 's/-Werror//' CMakeLists.txt

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,3 +21,8 @@ if(NOT WIN32)
     set_target_properties(hera PROPERTIES LINK_FLAGS "-Wl,-undefined,error")
   endif()
 endif()
+
+if(HERA_WAVM)
+    target_compile_definitions(hera PRIVATE HERA_WAVM=1)
+    target_link_libraries(hera PRIVATE wavm::wavm)
+endif()


### PR DESCRIPTION
This adds -DHERA_WAVM option what for now will build WAVM and link hera with it. Because Hera does not uses WAVM it will not do anything useful, but we can check if the build works.

Also the `HERA_WAVM=1` macro is predefined for build with WAVM.

This depends on LLVM 6.0 so you have to install libllvm-6.0-dev. See http://apt.llvm.org.

The WAVM produces a number of libraries. In this PR only the libruntime is used, probably more is going to be needed when we start using WAVM.