### PR TITLE
Trap OOB on externalcodecopy

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -395,7 +395,7 @@ inline int64_t maxCallGas(int64_t gas) {
       // FIXME: optimise this so no vector needs to be created
       vector<uint8_t> codeBuffer(length);
       size_t numCopied = context->fn_table->copy_code(context, &address, codeOffset, codeBuffer.data(), codeBuffer.size());
-      fill_n(&codeBuffer[numCopied], length - numCopied, 0);
+      ensureCondition(numCopied == length, InvalidMemoryAccess, "Out of bounds (source) memory copy");
 
       storeMemory(codeBuffer, 0, resultOffset, length);
 


### PR DESCRIPTION
Per https://github.com/ewasm/tests/issues/34 and https://github.com/ewasm/hera/pull/256#issuecomment-408501827 we want codecopy and extcodecopy to trap on OOB rather than zero padding.