### PR TITLE
Check for out of bounds source on memory copy

### DIFF
--- a/src/eei.h
+++ b/src/eei.h
@@ -65,6 +65,7 @@ private:
   void takeGas(uint64_t gas);
   void takeInterfaceGas(uint64_t gas);
 
+  void ensureSourceMemoryBounds(uint32_t offset, uint32_t length);
   void loadMemory(uint32_t srcOffset, uint8_t *dst, size_t length);
   void loadMemory(uint32_t srcOffset, std::vector<uint8_t> & dst, size_t length);
   void storeMemory(const uint8_t *src, uint32_t dstOffset, uint32_t length);


### PR DESCRIPTION
loadMemory was only checking for integer overflow/negative length. Also
check that we don't attempt to copy from beyond the end of memory. Also
perform the same check before attempting to resize a vector larger than
memory.

Tests in https://github.com/ewasm/tests/pull/57