### PR TITLE
Add option to preload system contracts from file before execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These are to be used via EVMC `set_option`:
 - `engine=<engine>` will select the underlying WebAssembly engine, where the only accepted value currently is `binaryen`
 - `metering=true` will enable metering of bytecode at deployment using the [Sentinel system contract](https://github.com/ewasm/design/blob/master/system_contracts.md#sentinel-contract) (set to `false` by default)
 - `evm1mode=<evm1mode>` will select how EVM1 bytecode is handled
+- `sys:<alias/address>=file.wasm` will override the code executing at the specified address with code loaded from a filepath at runtime. This option supports aliases for system contracts as well, such that `sys:sentinel=file.wasm` and `sys:evm2wasm=file.wasm` are both valid.
 
 ### evm1mode
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -34,6 +34,15 @@ string toHex(evmc_uint256be const& value) {
   return "0x" + os.str();
 }
 
+string bytesAsHexStr(const uint8_t *bytes, const size_t length) {
+  stringstream ret;
+  ret << hex << "0x";
+  for (size_t i = 0; i < length; ++i) {
+    ret << setw(2) << setfill('0') << static_cast<int>(bytes[i]);
+  }
+  return ret.str();
+}
+
 bool hasWasmPreamble(vector<uint8_t> const& _input) {
   return
     _input.size() >= 8 &&

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -24,6 +24,9 @@ namespace hera {
 
 std::string toHex(evmc_uint256be const& value);
 
+// Returns a formatted string (with prefix "0x") representing the bytes of an array.
+std::string bytesAsHexStr(const uint8_t *bytes, const size_t length);
+
 bool hasWasmPreamble(std::vector<uint8_t> const& _input);
 
 }

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -83,6 +83,7 @@ struct hera_instance : evmc_instance {
   std::unique_ptr<WasmEngine> engine{new BinaryenEngine};
   hera_evm_mode evm_mode = hera_evm_mode::reject;
   bool metering = false;
+  vector<pair<evmc_address, string>> contract_preload_list;
 
   hera_instance() noexcept : evmc_instance({EVMC_ABI_VERSION, "hera", hera_get_buildinfo()->project_version, nullptr, nullptr, nullptr, nullptr}) {}
 };
@@ -106,6 +107,53 @@ int hera_create_wasm_engine(struct hera_instance *hera, hera_wasm_engine engine)
 
 const evmc_address sentinelAddress = { .bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xa } };
 const evmc_address evm2wasmAddress = { .bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xb } };
+
+// Resolve an address on the preload list to a filepath containing the binary.
+// This assumes that the address is on the list, implying resolveSystemContract has been called.
+string resolvePreloadPath(const evmc_address* addr, const hera_instance *hera) {
+  auto const& list = hera->contract_preload_list;
+
+  for (size_t i = 0; i < list.size(); ++i) {
+    if (memcmp(list[i].first.bytes, addr->bytes, sizeof(evmc_address)) == 0) {
+      HERA_DEBUG << "Successfully resolved address " << bytesAsHexStr(addr->bytes, 20) << " to filepath " << list[i].second << "\n";
+      return string(list[i].second);
+    }
+  }
+
+  heraAssert(false, "The specified address could not be resolved to a filepath with its binary.");
+}
+
+// Returns the bytecode to be overridden before execution
+vector<uint8_t> overrideRunCode(const evmc_address *addr, const hera_instance *hera) {
+  const string path = resolvePreloadPath(addr, hera);
+
+  HERA_DEBUG << "Attempting to load file " << path << "\n";
+  ifstream fp;
+  fp.open(path.c_str(), ios::in | ios::binary);
+
+  if (!fp.is_open()) throw InternalErrorException(string("Failed to open WASM binary"));
+  
+  istreambuf_iterator<char> fp_start(fp), fp_end;
+  vector<char> bytecode(fp_start, fp_end);
+  HERA_DEBUG << "Successfully loaded file " << path << "\n";
+  // Replace the run code with the loaded bytecode
+  return vector<uint8_t>(bytecode.begin(), bytecode.end());
+}
+
+// Checks if the contract preload list contains the given address.
+bool resolveSystemContract(const hera_instance *hera, const evmc_address *addr) {
+  auto const& list = hera->contract_preload_list;
+
+  for (size_t i = 0; i < list.size(); ++i) {
+    if (memcmp(list[i].first.bytes, addr->bytes, sizeof(evmc_address)) == 0) {
+      HERA_DEBUG << "Successfully resolved address " << bytesAsHexStr(addr->bytes, 20) << "\n";
+      return true;
+    }
+  }
+
+  HERA_DEBUG << "Address does not match " << bytesAsHexStr(addr->bytes, 20) << "\n";
+  return false;
+}
 
 // Calls a system contract at @address with input data @input.
 // It is a "staticcall" with sender 000...000 and no value.
@@ -326,6 +374,12 @@ evmc_result hera_execute(
     heraAssert(hera->engine, "Wasm engine not set.");
     WasmEngine& engine = *hera->engine;
 
+    if (resolveSystemContract(hera, &msg->destination)) {
+      HERA_DEBUG << "Overriding contract\n";
+      run_code = overrideRunCode(&msg->destination, hera);
+      run_code.shrink_to_fit();
+    }
+
     ExecutionResult result = engine.execute(context, run_code, state_code, *msg, meterInterfaceGas);
     heraAssert(result.gasLeft >= 0, "Negative gas left after execution.");
 
@@ -388,6 +442,85 @@ evmc_result hera_execute(
   return ret;
 }
 
+// TODO: use C++17 and std::optional
+pair<evmc_address, bool> resolve_alias_to_address(string const& alias) {
+  const map<string, evmc_address> alias_to_addr_map = {
+    { string("sentinel"), sentinelAddress },
+    { string("evm2wasm"), evm2wasmAddress }
+  };
+
+  if (alias_to_addr_map.count(alias) != 0) {
+    return { alias_to_addr_map.at(alias), true };
+  }
+
+  return { evmc_address{}, false };
+}
+
+pair<evmc_address, bool> parse_hex_addr(string const& addr) {
+  evmc_address ret = {};
+
+  HERA_DEBUG << "Trying to parse address field\n";
+
+  if (addr.find("0x") != 0) { 
+    heraAssert(false, "Address missing '0x' prefix!");
+  }
+
+  heraAssert(addr.size() <= 42, "Address specified is too long!");
+
+  string addr_raw;
+  // If the number of nibbles is odd, we must prepend a zero for unmarshalling to work correctly.
+  if (addr.size() % 2 > 0) addr_raw.push_back('0');
+  addr_raw.append(addr.substr(2, string::npos));
+
+  size_t hex_length = addr_raw.size();
+
+  HERA_DEBUG << "Got hex string of length " << hex_length << ": " << addr_raw << "\n";
+
+  // Use strtol to parse hex string into binary
+  for (size_t i = hex_length / 2, j = 20; i > 0 && j > 0; i--, j--) {
+    string byte_str = addr_raw.substr(((i - 1) * 2), 2);
+
+    uint8_t byte = uint8_t(strtol(byte_str.c_str(), nullptr, 16));
+
+    ret.bytes[j - 1] = byte;
+  }
+
+  HERA_DEBUG << "Successfully unmarshalled hex string into address struct\n";
+
+  return pair<evmc_address, bool>(ret, true);
+}
+
+pair<evmc_address, bool> parse_preload_addr(const char *name)
+{
+  assert(name != nullptr);
+
+  pair<evmc_address, bool> ret = { {}, false };
+  string evmc_option_raw = string(name);
+
+  HERA_DEBUG << "Trying to parse EVMC option as preload flag: " << evmc_option_raw << "\n";
+
+  // Check the "sys:" syntax by comparing substring
+  if (evmc_option_raw.find("sys:") != 0) {
+    HERA_DEBUG << "Unsuccessfully parsed preload command, prefix malformed: " << evmc_option_raw.substr(0, 4) << "\n";
+    return ret;
+  }
+
+  // Parse the address field from the option name and try to determine an address
+  string opt_address_to_load = evmc_option_raw.substr(4, string::npos);
+
+  // Try to resolve the substring to an alias first
+  HERA_DEBUG << "Attempting to parse option as an alias: " << opt_address_to_load << "\n";
+  ret = resolve_alias_to_address(opt_address_to_load);
+
+  // If alias resolver returns false, try parsing to a hex address
+  if (ret.second == false) {
+    HERA_DEBUG << "Unsuccessfully resolved option to an alias, trying to unmarshal from a hex string\n";
+    ret = parse_hex_addr(opt_address_to_load);
+  }
+
+  return ret;
+}
+
 int hera_set_option(
   evmc_instance *instance,
   char const *name,
@@ -412,6 +545,12 @@ int hera_set_option(
     if (it != wasm_engine_options.end()) {
       return hera_create_wasm_engine(hera, it->second);
     }
+  }
+
+  auto preload_addr = parse_preload_addr(name);
+  if (preload_addr.second == true) {
+    hera->contract_preload_list.push_back(pair<evmc_address, string>(preload_addr.first, string(value)));
+    return 1;
   }
 
   return 0;


### PR DESCRIPTION
Closes #288 
Syntax: `--evmc sys:<address or alias>=<filepath>`
Hex address must be formatted with a leading `0x` and must be 40 characters long (all nibbles must be explicitly specified, including leading zeroes).