### PR TITLE
Extract EEI methods from within callImport (call, create, selfDestruct, returnDataCopy)

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -596,11 +596,7 @@ namespace hera {
     if (import->base == Name("getReturnDataSize")) {
       heraAssert(arguments.size() == 0, string("Argument count mismatch in: ") + import->base.str);
 
-      HERA_DEBUG << "getReturnDataSize\n";
-
-      takeInterfaceGas(GasSchedule::base);
-
-      return Literal(static_cast<uint32_t>(m_lastReturnData.size()));
+      return Literal(eeiGetReturnDataSize());
     }
 
     if (import->base == Name("returnDataCopy")) {
@@ -610,11 +606,7 @@ namespace hera {
       uint32_t offset = static_cast<uint32_t>(arguments[1].geti32());
       uint32_t size = static_cast<uint32_t>(arguments[2].geti32());
 
-      HERA_DEBUG << "returnDataCopy " << hex << dataOffset << " " << offset << " " << size << dec << "\n";
-      
-      safeChargeDataCopy(size, GasSchedule::verylow);
-
-      storeMemory(m_lastReturnData, offset, dataOffset, size);
+      eeiReturnDataCopy(dataOffset, offset, size);
 
       return Literal();
     }
@@ -683,6 +675,22 @@ namespace hera {
     }
 
     heraAssert(false, string("Unsupported import called: ") + import->module.str + "::" + import->base.str + " (" + to_string(arguments.size()) + "arguments)");
+  }
+
+  uint32_t EthereumInterface::eeiGetReturnDataSize()
+  {
+      HERA_DEBUG << "getReturnDataSize\n";
+
+      takeInterfaceGas(GasSchedule::base);
+      return static_cast<uint32_t>(m_lastReturnData.size());
+  }
+
+  void EthereumInterface::eeiReturnDataCopy(uint32_t dataOffset, uint32_t offset, uint32_t size)
+  {
+      HERA_DEBUG << "returnDataCopy " << hex << dataOffset << " " << offset << " " << size << dec << "\n";
+
+      safeChargeDataCopy(size, GasSchedule::verylow);
+      storeMemory(m_lastReturnData, offset, dataOffset, size);
   }
 
   uint32_t EthereumInterface::eeiCall(EEICallKind kind, int64_t gas, uint32_t addressOffset, uint32_t valueOffset, uint32_t dataOffset, uint32_t dataLength)

--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -582,15 +582,9 @@ namespace hera {
       uint32_t offset = static_cast<uint32_t>(arguments[0].geti32());
       uint32_t size = static_cast<uint32_t>(arguments[1].geti32());
 
-      HERA_DEBUG << (import->base == Name("revert") ? "revert " : "finish ") << hex << offset << " " << size << dec << "\n";
+      eeiRevertOrFinish(import->base == Name("revert"), offset, size);
 
-      ensureSourceMemoryBounds(offset, size);
-      m_result.returnValue = vector<uint8_t>(size);
-      loadMemory(offset, m_result.returnValue, size);
-
-      m_result.isRevert = import->base == Name("revert");
-
-      throw EndExecution{};
+      return Literal();
     }
 
     if (import->base == Name("getReturnDataSize")) {
@@ -675,6 +669,19 @@ namespace hera {
     }
 
     heraAssert(false, string("Unsupported import called: ") + import->module.str + "::" + import->base.str + " (" + to_string(arguments.size()) + "arguments)");
+  }
+
+  void EthereumInterface::eeiRevertOrFinish(bool revert, uint32_t offset, uint32_t size)
+  {
+      HERA_DEBUG << (revert ? "revert " : "finish ") << hex << offset << " " << size << dec << "\n";
+
+      ensureSourceMemoryBounds(offset, size);
+      m_result.returnValue = vector<uint8_t>(size);
+      loadMemory(offset, m_result.returnValue, size);
+
+      m_result.isRevert = revert;
+
+      throw EndExecution{};
   }
 
   uint32_t EthereumInterface::eeiGetReturnDataSize()

--- a/src/eei.h
+++ b/src/eei.h
@@ -76,6 +76,7 @@ private:
 
   // EEI methods
 
+  void eeiRevertOrFinish(bool revert, uint32_t offset, uint32_t size);
   uint32_t eeiGetReturnDataSize();
   void eeiReturnDataCopy(uint32_t dataOffset, uint32_t offset, uint32_t size);
   uint32_t eeiCall(EEICallKind kind, int64_t gas, uint32_t addressOffset, uint32_t valueOffset, uint32_t dataOffset, uint32_t dataLength);

--- a/src/eei.h
+++ b/src/eei.h
@@ -76,6 +76,8 @@ private:
 
   // EEI methods
 
+  uint32_t eeiGetReturnDataSize();
+  void eeiReturnDataCopy(uint32_t dataOffset, uint32_t offset, uint32_t size);
   uint32_t eeiCall(EEICallKind kind, int64_t gas, uint32_t addressOffset, uint32_t valueOffset, uint32_t dataOffset, uint32_t dataLength);
   uint32_t eeiCreate(uint32_t valueOffset, uint32_t dataOffset, uint32_t length, uint32_t resultOffset);
   void eeiSelfDestruct(uint32_t addressOffset);

--- a/src/eei.h
+++ b/src/eei.h
@@ -74,6 +74,14 @@ private:
     CallStatic
   };
 
+  // EEI methods
+
+  uint32_t eeiCall(EEICallKind kind, int64_t gas, uint32_t addressOffset, uint32_t valueOffset, uint32_t dataOffset, uint32_t dataLength);
+  uint32_t eeiCreate(uint32_t valueOffset, uint32_t dataOffset, uint32_t length, uint32_t resultOffset);
+  void eeiSelfDestruct(uint32_t addressOffset);
+
+  // Helpers methods
+
   void takeGas(int64_t gas);
   void takeInterfaceGas(int64_t gas);
 


### PR DESCRIPTION
Part of #156.

Inspired by #148.