### PR TITLE
Fix EVM compatibility in gas charges for ReturnDataCopy

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -644,7 +644,7 @@ inline int64_t maxCallGas(int64_t gas) {
 
       HERA_DEBUG << "returnDataCopy " << hex << dataOffset << " " << offset << " " << size << dec << "\n";
 
-      takeInterfaceGas(GasSchedule::verylow);
+      takeInterfaceGas(GasSchedule::verylow + GasSchedule::copy * ((size + 31) / 32));
       storeMemory(m_lastReturnData, offset, dataOffset, size);
 
       return Literal();


### PR DESCRIPTION
https://ethereum.github.io/yellowpaper/paper.pdf - appendix H shows that the cost for returndatacopy has changed to be more in the style of *copy.