### PR TITLE
Consider blockhash as bytes32 and not uint256

### DIFF
--- a/src/eei.cpp
+++ b/src/eei.cpp
@@ -260,7 +260,7 @@ namespace hera {
       if (isZeroUint256(blockhash))
         return Literal(uint32_t(1));
 
-      storeUint256(blockhash, resultOffset);
+      storeBytes32(blockhash, resultOffset);
 
       return Literal(uint32_t(0));
     }


### PR DESCRIPTION
Forgot in #351.