### PR TITLE
Simplify switch statements

### DIFF
--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -307,8 +307,6 @@ evmc_result hera_execute(
         HERA_DEBUG << "Non-WebAssembly input, failure.n\n";
         ret.status_code = EVMC_FAILURE;
         return ret;
-      default:
-        heraAssert(false, "");
       }
     } else if (msg->kind == EVMC_CREATE) {
       // Meter the deployment (constructor) code if it is WebAssembly


### PR DESCRIPTION
Default case is not needed when all enum values are handled. In case of mistake you get error like this
```
/home/builder/project/src/hera.cpp: In function 'evmc_result {anonymous}::hera_execute(evmc_instance*, evmc_context*, evmc_revision, const evmc_message*, const uint8_t*, size_t)':
/home/builder/project/src/hera.cpp:281:14: error: enumeration value 'reject' not handled in switch [-Werror=switch]
       switch (hera->evm_mode) {
              ^
```
CI protects it: https://circleci.com/gh/ewasm/hera/4624