### PR TITLE
Run evmc-vmtester on the built Hera shared library

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -123,6 +123,12 @@ defaults:
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --evmc engine=binaryen
 
+  evmc-test: &evmc-test
+    run:
+      name: "Run evmc tests"
+      command: |
+        ~/build/evmc/test/evmc-vmtester ~/build/src/libhera.so
+
   evm2wasm-test: &evm2wasm-test
     run:
       name: "Run evm2wasm state tests"
@@ -147,7 +153,7 @@ jobs:
       - CC:  clang
       - GENERATOR: Ninja
       - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF -DHERA_WAVM=ON -DHERA_WABT=ON
+      - CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF -DHERA_WAVM=ON -DHERA_WABT=ON -DEVMC_TESTING=ON
     docker:
       - image: ethereum/cpp-build-env:3
     steps:
@@ -163,6 +169,7 @@ jobs:
       - *store-hera
       - *fetch-tests
       - *test
+      - *evmc-test
       - *evm2wasm-test
 
   linux-gcc-shared-coverage:


### PR DESCRIPTION
This works locally too:
```
$ evmc/test/evmc-vmtester src/libhera.dylib 
Testing src/libhera.dylib

[==========] Running 6 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 6 tests from evmc_vm_test
[ RUN      ] evmc_vm_test.abi_version_match
[       OK ] evmc_vm_test.abi_version_match (0 ms)
[ RUN      ] evmc_vm_test.set_option_unknown
[       OK ] evmc_vm_test.set_option_unknown (0 ms)
[ RUN      ] evmc_vm_test.set_option_empty_value
[       OK ] evmc_vm_test.set_option_empty_value (0 ms)
[ RUN      ] evmc_vm_test.name
[       OK ] evmc_vm_test.name (0 ms)
[ RUN      ] evmc_vm_test.version
[       OK ] evmc_vm_test.version (0 ms)
[ RUN      ] evmc_vm_test.set_tracer
[       OK ] evmc_vm_test.set_tracer (0 ms)
[----------] 6 tests from evmc_vm_test (0 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 6 tests.
```