### PR TITLE
Move WasmEngine to Hera instance

### DIFF
--- a/src/binaryen.h
+++ b/src/binaryen.h
@@ -56,7 +56,7 @@ private:
   uint8_t memoryGet(size_t offset) override { return memory.get<uint8_t>(offset); }
 };
 
-class BinaryenEngine : WasmEngine {
+class BinaryenEngine : public WasmEngine {
 public:
   ExecutionResult execute(
     evmc_context* context,

--- a/src/binaryen.h
+++ b/src/binaryen.h
@@ -67,7 +67,7 @@ public:
   ) override;
 
 private:
-  void validate_contract(wasm::Module & module);
+  static void validate_contract(wasm::Module & module);
 };
 
 }

--- a/src/eei.h
+++ b/src/eei.h
@@ -32,6 +32,8 @@ struct ExecutionResult {
 
 class WasmEngine {
 public:
+  virtual ~WasmEngine() noexcept = default;
+
   virtual ExecutionResult execute(
     evmc_context* context,
     std::vector<uint8_t> const& code,

--- a/src/eei.h
+++ b/src/eei.h
@@ -30,6 +30,10 @@ struct ExecutionResult {
   bool isRevert = false;
 };
 
+// There is a single engine instance in each VM instance and
+// likely execute() is called multiple times. As a result
+// an engine implementation cannot have instance variables with
+// side-effects.
 class WasmEngine {
 public:
   virtual ~WasmEngine() noexcept = default;


### PR DESCRIPTION
Keep the Wasm Engine by owned pointer in the Hera instance. Pointer allows future polymorphic behavior.

Fixes #372.