### PR TITLE
Initial support for WAVM as an engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please also check the build options listed in the following section.
 
 ### WAVM support
 
-*Unfinished support, work in progress.*
+*Limited support, work in progress.*
 
 [WAVM] support needs to be enabled via the following build option and requested at runtime with `engine=wavm`:
 
@@ -55,7 +55,7 @@ Please also check the build options listed in the following section.
 
 These are to be used via EVMC `set_option`:
 
-- `engine=<engine>` will select the underlying WebAssembly engine, where the only accepted values currently are `binaryen` and `wabt`
+- `engine=<engine>` will select the underlying WebAssembly engine, where the only accepted values currently are `binaryen`, `wabt`, and 'wavm'
 - `metering=true` will enable metering of bytecode at deployment using the [Sentinel system contract] (set to `false` by default)
 - `evm1mode=<evm1mode>` will select how EVM1 bytecode is handled
 - `sys:<alias/address>=file.wasm` will override the code executing at the specified address with code loaded from a filepath at runtime. This option supports aliases for system contracts as well, such that `sys:sentinel=file.wasm` and `sys:evm2wasm=file.wasm` are both valid. **This option is intended for debugging purposes.**

--- a/circle.yml
+++ b/circle.yml
@@ -143,6 +143,15 @@ defaults:
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "getGasLeftUseAllGas" --evmc engine=wabt
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "returnPredefinedData" --evmc engine=wabt
 
+  test-wavm: &test-wavm
+    run:
+      name: "Test shared Hera (wavm)"
+      command: |
+        if [[ $PRELOAD_ASAN ]]; then export LD_PRELOAD=/usr/lib/clang/6.0/lib/linux/libclang_rt.asan-x86_64.so; fi
+        testeth --version
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "useGas" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "createFromTransaction" --evmc engine=wavm
+
   evmc-test: &evmc-test
     run:
       name: "Run evmc tests"
@@ -190,6 +199,7 @@ jobs:
       - *fetch-tests
       - *test
       - *test-wabt
+      - *test-wavm
       - *evmc-test
       - *evm2wasm-test
 

--- a/circle.yml
+++ b/circle.yml
@@ -152,9 +152,11 @@ defaults:
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "useGas" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "createFromTransaction" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "storageStore" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "storageLoad" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "getCallDataSize" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "callDataCopy" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "callDataCopy256" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "getGasLeft" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "getGasLeftUseAllGas" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "returnPredefinedData" --evmc engine=wavm
 

--- a/circle.yml
+++ b/circle.yml
@@ -151,6 +151,12 @@ defaults:
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "useGas" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "createFromTransaction" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "storageStore" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "getCallDataSize" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "callDataCopy" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "callDataCopy256" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "getGasLeftUseAllGas" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "returnPredefinedData" --evmc engine=wavm
 
   evmc-test: &evmc-test
     run:

--- a/cmake/ProjectWAVM.cmake
+++ b/cmake/ProjectWAVM.cmake
@@ -29,8 +29,8 @@ ExternalProject_Add(wavm
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/AndrewScheidecker/WAVM/archive/a0baaec170b55cc60cfe6bcc6b36add953a065d8.tar.gz
-    URL_HASH SHA256=da184e2c077e257dea82c13b2e5ae1fc03d1dc306a1c9a6f84838cff7390b75a
+    URL https://github.com/AndrewScheidecker/WAVM/archive/2c77c8a2e49bd291833d79fe6c68801b44ae634c.tar.gz
+    URL_HASH SHA256=044b09afb6b62e0b1ad16dde3ef773f72dd077d7c54c88d6716162caa9eca2e7
     PATCH_COMMAND sh ${CMAKE_CURRENT_LIST_DIR}/patch_wavm.sh
     CMAKE_ARGS
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,10 @@ if(HERA_WABT)
   target_sources(hera PRIVATE wabt.cpp wabt.h)
 endif()
 
+if(HERA_WAVM)
+  target_sources(hera PRIVATE wavm.cpp wavm.h)
+endif()
+
 option(HERA_DEBUGGING "Display debugging messages during execution." ON)
 if(HERA_DEBUGGING)
   target_compile_definitions(hera PRIVATE HERA_DEBUGGING=1)

--- a/src/eei.h
+++ b/src/eei.h
@@ -72,7 +72,12 @@ public:
     m_context->fn_table->get_tx_context(&m_tx_context, m_context);
   }
 
+// WAVM host functions access this interface through an instance,
+// which requires public methods.
+// TODO: update upstream WAVM to have a context (user data) passed down.
+#if HERA_WAVM == 0
 protected:
+#endif
   virtual size_t memorySize() const = 0 ;
   virtual void memorySet(size_t offset, uint8_t value) = 0;
   virtual uint8_t memoryGet(size_t offset) = 0;

--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -31,6 +31,9 @@
 #include "eei.h"
 #include "exceptions.h"
 #include "helpers.h"
+#if HERA_WAVM
+#include "wavm.h"
+#endif
 #if HERA_WABT
 #include "wabt.h"
 #endif
@@ -66,7 +69,7 @@ using WasmEngineCreateFn = unique_ptr<WasmEngine>(*)();
 const map<string, WasmEngineCreateFn> wasm_engine_map {
   { "binaryen", BinaryenEngine::create },
 #if HERA_WAVM
-  { "wavm", []{ return unique_ptr<WasmEngine>{}; } },
+  { "wavm", WavmEngine::create },
 #endif
 #if HERA_WABT
   { "wabt", WabtEngine::create },

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -126,9 +126,11 @@ namespace wavm_host_module {
       IR::ObjectType type,
       Runtime::Object*& outObject) override
     {
+      outObject = nullptr;
       auto namedInstance = moduleNameToInstanceMap.get(moduleName);
-      outObject = Runtime::getInstanceExport(*namedInstance, exportName);
-      return true;
+      if (namedInstance)
+          outObject = Runtime::getInstanceExport(*namedInstance, exportName);
+      return outObject != nullptr;
     }
   };
 } // namespace wavm_host_module

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -142,6 +142,15 @@ ExecutionResult WavmEngine::execute(
 ) {
   HERA_DEBUG << "Executing with wavm...\n";
 
+  // Collect garbage left by previous runs.
+  //
+  // GCPointer<> marks objects to be deleted upon moving out of scope, however
+  // since all the objects are part of this call, `collectGarbage` at the end
+  // won't actually clean anything.
+  //
+  // Here we try to clean up after previous runs.
+  Runtime::collectGarbage();
+
   // set up a new ethereum interface just for this contract invocation
   ExecutionResult result;
   WavmEthereumInterface interface{context, state_code, msg, result, meterInterfaceGas};
@@ -200,7 +209,8 @@ ExecutionResult WavmEngine::execute(
 
   // clean up
   wavm_host_module::interface.pop();
-  // TODO: does this actually clean up all GCPointers above?
+
+  // This likely won't clear any memory, but we can be hopeful.
   Runtime::collectGarbage();
 
   return result;

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -72,9 +72,21 @@ namespace wavm_host_module {
   }
 
 
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "getGasLeft", U64, getGasLeft)
+  {
+    return static_cast<U64>(interface.top()->eeiGetGasLeft());
+  }
+
+
   DEFINE_INTRINSIC_FUNCTION(ethereum, "storageStore", void, storageStore, U32 pathOffset, U32 valueOffset)
   {
     interface.top()->eeiStorageStore(pathOffset, valueOffset);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "storageLoad", void, storageLoad, U32 pathOffset, U32 valueOffset)
+  {
+    interface.top()->eeiStorageLoad(pathOffset, valueOffset);
   }
 
 

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2018 Paul Dworzanski
+ * Copyright 2016-2018 Alex Beregszaszi et al.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wavm.h"
+#include "debugging.h"
+#include "eei.h"
+#include "exceptions.h"
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
+using namespace std;
+
+namespace hera {
+
+unique_ptr<WasmEngine> WavmEngine::create()
+{
+  return unique_ptr<WasmEngine>{new WavmEngine};
+}
+
+namespace wavm_host_module {
+  // first the ethereum interface(s), the top of the stack is used in host functions
+  stack<WavmEthereumInterface*> interface;
+
+
+  // the host module is called 'ethereum'
+  DEFINE_INTRINSIC_MODULE(ethereum)
+
+
+  // host functions follow
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "useGas", void, useGas, I64 amount)
+  {
+    interface.top()->eeiUseGas(amount);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "getAddress", void, getAddress, U32 resultOffset)
+  {
+    interface.top()->eeiGetAddress(resultOffset);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "call", U32, call, I64 gas, U32 addressOffset, U32 valueOffset, U32 dataOffset, U32 dataLength)
+  {
+    return interface.top()->eeiCall(EthereumInterface::EEICallKind::Call, gas, addressOffset, valueOffset, dataOffset, dataLength);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "callDataCopy", void, callDataCopy, U32 resultOffset, U32 dataOffset, U32 length)
+  {
+    interface.top()->eeiCallDataCopy(resultOffset, dataOffset, length);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "getCallDataSize", U32, getCallDataSize)
+  {
+    return interface.top()->eeiGetCallDataSize();
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "storageStore", void, storageStore, U32 pathOffset, U32 valueOffset)
+  {
+    interface.top()->eeiStorageStore(pathOffset, valueOffset);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "codeCopy", void, codeCopy, U32 resultOffset, U32 codeOffset, U32 length)
+  {
+    interface.top()->eeiCodeCopy(resultOffset, codeOffset, length);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "getCodeSize", U32, getCodeSize)
+  {
+    return interface.top()->eeiGetCodeSize();
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "finish", void, finish, U32 dataOffset, U32 length)
+  {
+    interface.top()->eeiFinish(dataOffset, length);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "revert", void, revert, U32 dataOffset, U32 length)
+  {
+    interface.top()->eeiRevert(dataOffset, length);
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "getReturnDataSize", U32, getReturnDataSize)
+  {
+    return interface.top()->eeiGetReturnDataSize();
+  }
+
+
+  DEFINE_INTRINSIC_FUNCTION(ethereum, "returnDataCopy", void, returnDataCopy, U32 resultOffset, U32 dataOffset, U32 length)
+  {
+    return interface.top()->eeiReturnDataCopy(resultOffset, dataOffset, length);
+  }
+
+
+  // this is needed for resolving names of imported host functions
+  struct HeraWavmResolver : Runtime::Resolver {
+    Runtime::Compartment* compartment;
+    HashMap<string, Runtime::ModuleInstance*> moduleNameToInstanceMap;
+
+    HeraWavmResolver(Runtime::Compartment* inCompartment) : compartment(inCompartment) {}
+
+    bool resolve(const string& moduleName,
+      const string& exportName,
+      IR::ObjectType type,
+      Runtime::Object*& outObject) override
+    {
+      auto namedInstance = moduleNameToInstanceMap.get(moduleName);
+      outObject = Runtime::getInstanceExport(*namedInstance, exportName);
+      return true;
+    }
+  };
+} // namespace wavm_host_module
+
+ExecutionResult WavmEngine::execute(
+  evmc_context* context,
+  vector<uint8_t> const& code,
+  vector<uint8_t> const& state_code,
+  evmc_message const& msg,
+  bool meterInterfaceGas
+) {
+  HERA_DEBUG << "Executing with wavm...\n";
+
+  // set up a new ethereum interface just for this contract invocation
+  ExecutionResult result;
+  WavmEthereumInterface interface{context, state_code, msg, result, meterInterfaceGas};
+  wavm_host_module::interface.push(&interface);
+
+  // first parse module
+  vector<U8> codeBytes = static_cast<vector<U8>>(code);
+  IR::Module moduleAST; 
+  bool loadedSuccess = loadBinaryModule(codeBytes.data(), codeBytes.size(), moduleAST);
+  heraAssert(loadedSuccess, "wavm couldn't parse module into syntax tree");
+
+  // next set up the host module.
+  // Note: in ewasm, we create a new VM for each call to a module, so we must instantiate a new host module for each of these VMs, this is inefficient, but OK for prototyping.
+  // compartment is like the Wasm store, represents the VM, has lists of globals, memories, tables, and also has wavm's runtime stuff
+  Runtime::GCPointer<Runtime::Compartment> compartment = Runtime::createCompartment();
+  // context stores the compartment and some other stuff
+  Runtime::GCPointer<Runtime::Context> wavm_context = Runtime::createContext(compartment);
+  // instantiate host Module
+  HashMap<string, Runtime::Object*> extraEthereumExports; //empty for current ewasm stuff
+  Runtime::GCPointer<Runtime::ModuleInstance> ethereumHostModule = Intrinsics::instantiateModule(compartment, wavm_host_module::INTRINSIC_MODULE_REF(ethereum), "ethereum", extraEthereumExports);
+  heraAssert(ethereumHostModule, "wavm couldn't instantiate host module");
+  // prepare contract module to resolve links against host module
+  wavm_host_module::HeraWavmResolver resolver(compartment);
+  resolver.moduleNameToInstanceMap.set("ethereum", ethereumHostModule);
+  Runtime::LinkResult linkResult = Runtime::linkModule(moduleAST, resolver);
+  heraAssert(linkResult.success, "wavm couldn't link contract against host module");
+
+  // instantiate contract module
+  Runtime::GCPointer<Runtime::ModuleInstance> moduleInstance = Runtime::instantiateModule(compartment, moduleAST, move(linkResult.resolvedImports), "<ewasmcontract>");
+  heraAssert(moduleInstance, "wavm couldn't instantiate contract module");
+
+  // get memory for easy access in host functions
+  wavm_host_module::interface.top()->setWasmMemory(asMemory(Runtime::getInstanceExport(moduleInstance, "memory")));
+
+  // invoke the main function
+  Runtime::GCPointer<Runtime::FunctionInstance> functionInstance = asFunctionNullable(Runtime::getInstanceExport(moduleInstance, "main"));
+  heraAssert(functionInstance, "wavm couldn't find main function");
+
+  // this is how WAVM's try/catch for exceptions
+  Runtime::catchRuntimeExceptions(
+    [&] {
+      try {
+        vector<IR::Value> invokeArgs;
+        Runtime::invokeFunctionChecked(wavm_context, functionInstance, invokeArgs);
+      } catch (EndExecution const&) {
+        HERA_DEBUG << "Caught EndToEnd exception\n";
+        // This exception is ignored here because we consider it to be a success.
+        // It is only a clutch for POSIX style exit()
+      }
+    },
+    [&](Runtime::Exception&& exception) {
+      HERA_DEBUG << "Caught WAVM runtime exception\n";
+      // Perhaps this exception is ignored too, or maybe call revert
+    }
+  );
+
+  // clean up
+  wavm_host_module::interface.pop();
+  // TODO: does this actually clean up all GCPointers above?
+  Runtime::collectGarbage();
+
+  return result;
+}
+
+} // namespace hera

--- a/src/wavm.h
+++ b/src/wavm.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Paul Dworzanski
+ * Copyright 2016-2018 Alex Beregszaszi et al.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <stack>
+
+#define DLL_IMPORT // Needed by wavm on some platforms
+#include "Inline/CLI.h"
+#include "Runtime/Intrinsics.h"
+#include "Runtime/Linker.h"
+#include "Runtime/Runtime.h"
+
+#include "eei.h"
+
+namespace hera {
+
+class WavmEthereumInterface : public EthereumInterface {
+
+public:
+  explicit WavmEthereumInterface(
+    evmc_context* _context,
+    std::vector<uint8_t> const& _code,
+    evmc_message const& _msg,
+    ExecutionResult & _result,
+    bool _meterGas
+  ):
+    EthereumInterface(_context, _code, _msg, _result, _meterGas)
+  {}
+
+  void setWasmMemory(Runtime::MemoryInstance* _wasmMemory) {
+    m_wasmMemory = _wasmMemory;
+  }
+
+private:
+  // These assume that m_wasmMemory was set prior to execution.
+  size_t memorySize() const override { return Runtime::getMemoryNumPages(m_wasmMemory) * 65536; }
+  void memorySet(size_t offset, uint8_t value) override { (Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, 1))[0] = value; }
+  uint8_t memoryGet(size_t offset) override { return (Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, 1))[0]; }
+
+  Runtime::MemoryInstance* m_wasmMemory;
+};
+
+class WavmEngine : public WasmEngine {
+public:
+  /// Factory method to create the WABT Wasm Engine.
+  static std::unique_ptr<WasmEngine> create();
+
+  ExecutionResult execute(
+    evmc_context* context,
+    std::vector<uint8_t> const& code,
+    std::vector<uint8_t> const& state_code,
+    evmc_message const& msg,
+    bool meterInterfaceGas
+  ) override;
+};
+
+} // namespace hera


### PR DESCRIPTION
Early version of wavm execution in Hera. Should compile with `cmake -DHERA_WAVM=ON`. May need some work.

Closes #158.

Depends on #401.