### PR TITLE
CMake: Compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,10 @@ set(PROJECT_VERSION 0.1.0)
 cable_set_build_type(DEFAULT RelWithDebInfo CONFIGURATION_TYPES Debug;Release;RelWithDebInfo)
 
 cable_configure_compiler()
-# TODO: fix the warnings instead
-add_compile_options(-Wno-pedantic)
+if(CABLE_COMPILER_GNULIKE)
+    # TODO: fix the warnings instead
+    add_compile_options(-Wno-pedantic)
+endif()
 
 include(ProjectBinaryen)
 


### PR DESCRIPTION
Closes #373 

This adds `-Wswitch-enum` flag for Hera library.
The `-Wimplicit-fallthrough` was added earlier with `cable_configure_compiler()`.

Also it updates the Cable to avoid the "old version" warning.