### PR TITLE
update wavm to new version, and related fixes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -121,6 +121,7 @@ defaults:
     run:
       name: "Test shared Hera"
       command: |
+        ASAN_OPTIONS=detect_leaks=1
         if [[ $PRELOAD_ASAN ]]; then export LD_PRELOAD=/usr/lib/clang/6.0/lib/linux/libclang_rt.asan-x86_64.so; fi
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --evmc engine=binaryen
@@ -129,6 +130,7 @@ defaults:
     run:
       name: "Test shared Hera (wabt)"
       command: |
+        ASAN_OPTIONS=detect_leaks=1
         if [[ $PRELOAD_ASAN ]]; then export LD_PRELOAD=/usr/lib/clang/6.0/lib/linux/libclang_rt.asan-x86_64.so; fi
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "useGas" --evmc engine=wabt
@@ -147,6 +149,7 @@ defaults:
     run:
       name: "Test shared Hera (wavm)"
       command: |
+        ASAN_OPTIONS=detect_leaks=1
         if [[ $PRELOAD_ASAN ]]; then export LD_PRELOAD=/usr/lib/clang/6.0/lib/linux/libclang_rt.asan-x86_64.so; fi
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "useGas" --evmc engine=wavm
@@ -222,7 +225,6 @@ jobs:
       CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF -DHERA_WAVM=ON -DHERA_WABT=ON -DEVMC_TESTING=ON -DSANITIZE=address
       # The ASan must the first loaded shared library. Force preloading it with this flag.
       PRELOAD_ASAN: true
-      ASAN_OPTIONS: detect_leaks=0
 
   linux-gcc-shared-coverage:
     environment:

--- a/circle.yml
+++ b/circle.yml
@@ -121,7 +121,6 @@ defaults:
     run:
       name: "Test shared Hera"
       command: |
-        ASAN_OPTIONS=detect_leaks=1
         if [[ $PRELOAD_ASAN ]]; then export LD_PRELOAD=/usr/lib/clang/6.0/lib/linux/libclang_rt.asan-x86_64.so; fi
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --evmc engine=binaryen
@@ -130,7 +129,6 @@ defaults:
     run:
       name: "Test shared Hera (wabt)"
       command: |
-        ASAN_OPTIONS=detect_leaks=1
         if [[ $PRELOAD_ASAN ]]; then export LD_PRELOAD=/usr/lib/clang/6.0/lib/linux/libclang_rt.asan-x86_64.so; fi
         testeth --version
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.so --singlenet Byzantium --singletest "useGas" --evmc engine=wabt

--- a/circle.yml
+++ b/circle.yml
@@ -223,6 +223,7 @@ jobs:
       CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF -DHERA_WAVM=ON -DHERA_WABT=ON -DEVMC_TESTING=ON -DSANITIZE=address
       # The ASan must the first loaded shared library. Force preloading it with this flag.
       PRELOAD_ASAN: true
+      ASAN_OPTIONS: detect_leaks=0
 
   linux-gcc-shared-coverage:
     environment:

--- a/cmake/ProjectWAVM.cmake
+++ b/cmake/ProjectWAVM.cmake
@@ -20,8 +20,10 @@ set(wasm_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}WASM${CMAKE_STA
 set(ir_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}IR${CMAKE_STATIC_LIBRARY_SUFFIX})
 set(logging_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}Logging${CMAKE_STATIC_LIBRARY_SUFFIX})
 set(unwind_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}WAVMUnwind${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(llvmjit_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LLVMJIT${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-set(other_libraries ${platform_library} ${wasm_library} ${ir_library} ${logging_library} ${unwind_library})
+set(other_libraries ${platform_library} ${wasm_library} ${ir_library} ${logging_library} ${unwind_library} ${llvmjit_library})
+
 
 ExternalProject_Add(wavm
     PREFIX ${prefix}
@@ -29,8 +31,8 @@ ExternalProject_Add(wavm
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/AndrewScheidecker/WAVM/archive/2c77c8a2e49bd291833d79fe6c68801b44ae634c.tar.gz
-    URL_HASH SHA256=044b09afb6b62e0b1ad16dde3ef773f72dd077d7c54c88d6716162caa9eca2e7
+    URL https://github.com/AndrewScheidecker/WAVM/archive/b15e29f2ee361379742957d764aca655ef2a9e48.tar.gz
+    URL_HASH SHA256=fd6aa9261cf6bc21098e0c86ed68383a281dc6720455c75afdcdceeddbbc2dee
     PATCH_COMMAND sh ${CMAKE_CURRENT_LIST_DIR}/patch_wavm.sh
     CMAKE_ARGS
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/ProjectWAVM.cmake
+++ b/cmake/ProjectWAVM.cmake
@@ -31,14 +31,15 @@ ExternalProject_Add(wavm
     DOWNLOAD_DIR ${prefix}/downloads
     SOURCE_DIR ${source_dir}
     BINARY_DIR ${binary_dir}
-    URL https://github.com/AndrewScheidecker/WAVM/archive/b15e29f2ee361379742957d764aca655ef2a9e48.tar.gz
-    URL_HASH SHA256=fd6aa9261cf6bc21098e0c86ed68383a281dc6720455c75afdcdceeddbbc2dee
+    URL https://github.com/AndrewScheidecker/WAVM/archive/fa5434e03efbc2154ecf4aafede169da76a4da40.tar.gz
+    URL_HASH SHA256=1a380461ca6570b39d548dcedfacb3c105769d5d5957e85674253250f585c07d
     PATCH_COMMAND sh ${CMAKE_CURRENT_LIST_DIR}/patch_wavm.sh
     CMAKE_ARGS
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    -DCMAKE_BUILD_TYPE=Release
+    #-DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo
     -DLLVM_DIR=${LLVM_DIR}
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DCMAKE_CXX_FLAGS=-Wno-error

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -171,11 +171,11 @@ ExecutionResult WavmEngine::execute(
   wavm_host_module::interface.push(&interface);
 
   // first parse module
-  IR::Module moduleAST;
+  IR::Module irmodule;
   try {
     // NOTE: this expects U8, which is a typedef over uint8_t
     Serialization::MemoryInputStream input(code.data(), code.size());
-    WASM::serialize(input, moduleAST);
+    WASM::serialize(input, irmodule);
   } catch (Serialization::FatalSerializationException const& e) {
     ensureCondition(false, ContractValidationFailure, "Failed to deserialise contract: " + e.message);
   } catch (IR::ValidationException const& e) {
@@ -185,24 +185,29 @@ ExecutionResult WavmEngine::execute(
     ensureCondition(false, ContractValidationFailure, "Bug in wavm: didn't check bounds before allocation");
   }
 
-  // next set up the host module.
-  // Note: in ewasm, we create a new VM for each call to a module, so we must instantiate a new host module for each of these VMs, this is inefficient, but OK for prototyping.
+  // compile the module (not sure what this does)
+  Runtime::Module* module = Runtime::compileModule(irmodule);
+
+  // set up the VM
   // compartment is like the Wasm store, represents the VM, has lists of globals, memories, tables, and also has wavm's runtime stuff
   Runtime::GCPointer<Runtime::Compartment> compartment = Runtime::createCompartment();
   // context stores the compartment and some other stuff
   Runtime::GCPointer<Runtime::Context> wavm_context = Runtime::createContext(compartment);
-  // instantiate host Module
+
+  // set up the host Module
+  // Note: in ewasm, we create a new VM for each call to a module, so we must instantiate a new host module for each of these VMs, this is inefficient, but OK for prototyping.
   HashMap<string, Runtime::Object*> extraEthereumExports; //empty for current ewasm stuff
+  // instantiate host Module
   Runtime::GCPointer<Runtime::ModuleInstance> ethereumHostModule = Intrinsics::instantiateModule(compartment, wavm_host_module::INTRINSIC_MODULE_REF(ethereum), "ethereum", extraEthereumExports);
   heraAssert(ethereumHostModule, "Failed to create host module.");
   // prepare contract module to resolve links against host module
   wavm_host_module::HeraWavmResolver resolver(compartment);
   resolver.moduleNameToInstanceMap.set("ethereum", ethereumHostModule);
-  Runtime::LinkResult linkResult = Runtime::linkModule(moduleAST, resolver);
+  Runtime::LinkResult linkResult = Runtime::linkModule(irmodule, resolver);
   heraAssert(linkResult.success, "Couldn't link contract against host module.");
 
   // instantiate contract module
-  Runtime::GCPointer<Runtime::ModuleInstance> moduleInstance = Runtime::instantiateModule(compartment, moduleAST, move(linkResult.resolvedImports), "<ewasmcontract>");
+  Runtime::GCPointer<Runtime::ModuleInstance> moduleInstance = Runtime::instantiateModule(compartment, module, move(linkResult.resolvedImports), "<ewasmcontract>");
   heraAssert(moduleInstance, "Couldn't instantiate contact module.");
 
   // get memory for easy access in host functions

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -147,7 +147,7 @@ namespace wavm_host_module {
   };
 } // namespace wavm_host_module
 
-ExecutionResult WavmEngine::execute(
+ExecutionResult WavmEngine::internalExecute(
   evmc_context* context,
   vector<uint8_t> const& code,
   vector<uint8_t> const& state_code,
@@ -155,15 +155,6 @@ ExecutionResult WavmEngine::execute(
   bool meterInterfaceGas
 ) {
   HERA_DEBUG << "Executing with wavm...\n";
-
-  // Collect garbage left by previous runs.
-  //
-  // GCPointer<> marks objects to be deleted upon moving out of scope, however
-  // since all the objects are part of this call, `collectGarbage` at the end
-  // won't actually clean anything.
-  //
-  // Here we try to clean up after previous runs.
-  Runtime::collectGarbage();
 
   // set up a new ethereum interface just for this contract invocation
   ExecutionResult result;
@@ -236,9 +227,6 @@ ExecutionResult WavmEngine::execute(
 
   // clean up
   wavm_host_module::interface.pop();
-
-  // This likely won't clear any memory, but we can be hopeful.
-  Runtime::collectGarbage();
 
   return result;
 }

--- a/src/wavm.h
+++ b/src/wavm.h
@@ -47,7 +47,7 @@ public:
     EthereumInterface(_context, _code, _msg, _result, _meterGas)
   {}
 
-  void setWasmMemory(Runtime::MemoryInstance* _wasmMemory) {
+  void setWasmMemory(Runtime::GCPointer<Runtime::MemoryInstance> _wasmMemory) {
     m_wasmMemory = _wasmMemory;
   }
 
@@ -57,7 +57,7 @@ private:
   void memorySet(size_t offset, uint8_t value) override { (Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, 1))[0] = value; }
   uint8_t memoryGet(size_t offset) override { return (Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, 1))[0]; }
 
-  Runtime::MemoryInstance* m_wasmMemory;
+  Runtime::GCPointer<Runtime::MemoryInstance> m_wasmMemory;
 };
 
 class WavmEngine : public WasmEngine {
@@ -71,7 +71,21 @@ public:
     std::vector<uint8_t> const& state_code,
     evmc_message const& msg,
     bool meterInterfaceGas
-  ) override;
+  ) override {
+    ExecutionResult result = internalExecute(context, code, state_code, msg, meterInterfaceGas);
+    // And clean up mess left by this run.
+    Runtime::collectGarbage();
+    return result;
+  }
+
+private:
+  ExecutionResult internalExecute(
+    evmc_context* context,
+    std::vector<uint8_t> const& code,
+    std::vector<uint8_t> const& state_code,
+    evmc_message const& msg,
+    bool meterInterfaceGas
+  );
 };
 
 } // namespace hera


### PR DESCRIPTION
WAVM recently had an overhaul, including changes to the API. This pull request updates hera to use this overhauled version and API.

Test cases passing are `useGas`, `getCallDataSize`, `callDataCopy`, `callDataCopy256`, `revert`, and `returnPredefinedData`.

Test cases still failing are `revertVeryLong` and `returnVeryLong`. Errors follow.

```
ewasm@ewasm-workstation3:~/pauls_stuff/20180914$ ETHEREUM_TEST_PATH=tests aleth/bin/testeth -t GeneralStateTests/stEWASMTests -- --vm hera/BUILD/src/libhera.so --evmc engine=wavm --singlenet "Byzantium" --singletest revertVeryLong
[2018-09-14 18:29:53.818346] [0x00007fa05197d800] [info]    Loading EVMC module: hera/BUILD/src/libhera.so
Running tests using path: "tests"
Running 1 test case...
Test Case "stEWASMTests": 
100%
Executing message in Hera
Executing with wavm...
call 186a0 0 20 20 1
Executing message in Hera
Executing with wavm...
revert 0 ffffffff
Out of bounds (source) memory copy.
getReturnDataSize
Out of gas.
/home/builder/project/test/tools/libtesteth/ImportTest.cpp(753): error: in "GeneralStateTests/stEWASMTests": revertVeryLong on Byzantium: Expected another postState hash! expected: 0x87cc1003df1e165b599804494aa4562d3e524053ae8cf184766fe0ac17ccfbfc actual: 0xa413bb0f634232fde6adecf7796a54d8d932f96ac15ce9099453982d7dd23f2a in Byzantium data: 0 gas: 0 val: 0

*** 1 failure is detected (5 failures are expected) in the test module "Master Test Suite"

ewasm@ewasm-workstation3:~/pauls_stuff/20180914$ ETHEREUM_TEST_PATH=tests aleth/bin/testeth -t GeneralStateTests/stEWASMTests -- --vm hera/BUILD/src/libhera.so --evmc engine=wavm --singlenet "Byzantium" --singletest returnVeryLong
[2018-09-14 18:30:02.105802] [0x00007feb57a0f800] [info]    Loading EVMC module: hera/BUILD/src/libhera.so
Running tests using path: "tests"
Running 1 test case...
Test Case "stEWASMTests": 
100%
Executing message in Hera
Executing with wavm...
call 186a0 0 20 20 1
Executing message in Hera
Executing with wavm...
finish 0 ffffffff
Out of bounds (source) memory copy.
getReturnDataSize
Out of gas.
/home/builder/project/test/tools/libtesteth/ImportTest.cpp(753): error: in "GeneralStateTests/stEWASMTests": returnVeryLong on Byzantium: Expected another postState hash! expected: 0x18dd6b7c1ba4192101c8d1d9705065c853b90eecc9bd1f534ec0bdbff3e40df3 actual: 0x1632e5143bafebca6bda327956a48b8e179f12a7210295adde51fc706695c789 in Byzantium data: 0 gas: 0 val: 0

*** 1 failure is detected (5 failures are expected) in the test module "Master Test Suite"
```