### PR TITLE
CMake: Build shared libraries by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ include(ProjectBinaryen)
 
 cable_add_buildinfo_library(PROJECT_NAME hera)
 
+option(BUILD_SHARED_LIBS "Build libraries as shared" ON)
+
 option(HERA_WABT "Build with wabt" OFF)
 if (HERA_WABT)
     include(ProjectWabt)

--- a/circle.yml
+++ b/circle.yml
@@ -248,14 +248,14 @@ jobs:
       - *test
       - *upload-coverage-data
 
-  linux-gcc-debug:
+  linux-gcc-static-debug:
     environment:
       - BUILD_TYPE: Debug
       - CXX: g++
       - CC:  gcc
       - GENERATOR: Unix Makefiles
       - BUILD_PARALLEL_JOBS: 4
-      - CMAKE_OPTIONS: -DHERA_DEBUGGING=ON -DHERA_WAVM=ON -DHERA_WABT=ON
+      - CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=OFF -DHERA_DEBUGGING=ON -DHERA_WAVM=ON -DHERA_WABT=ON
     docker:
       - image: ethereum/cpp-build-env:5
     steps:
@@ -282,4 +282,4 @@ workflows:
       - linux-clang-shared-release
       - linux-clang-shared-asan
       - linux-gcc-shared-coverage
-      - linux-gcc-debug
+      - linux-gcc-static-debug


### PR DESCRIPTION
This change sets the BUILD_SHARED_LIBS flag to ON by default.

Closes https://github.com/ewasm/hera/issues/413.