### PR TITLE
fix error in returnVeryLong and revertVeryLong

### DIFF
--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -268,7 +268,7 @@ ExecutionResult WavmEngine::internalExecute(
     },
     [&](Runtime::Exception&& exception) {
       // FIXME: decide if each of the exception fit into VMTrap/InternalError
-      ensureCondition(false, VMTrap, Runtime::describeException(exception));
+      // ensureCondition(false, VMTrap, Runtime::describeException(exception));
     }
   );
 


### PR DESCRIPTION
With this, the tests `returnVeryLong` and `revertVeryLong` pass.