### PR TITLE
disable exports check until metering contract is fixed

### DIFF
--- a/src/binaryen.cpp
+++ b/src/binaryen.cpp
@@ -515,11 +515,16 @@ ExecutionResult BinaryenEngine::execute(
     "Contract export (\"memory\") missing."
   );
 
+  // disable this check for exports.size == 2
+  // because currently the metering contract has more than 2 exports
+  // waiting on fix of metering contract
+  /*
   ensureCondition(
     module.exports.size() == 2,
     ContractValidationFailure,
     "Contract exports more than (\"main\") and (\"memory\")."
   );
+  */
 
   for (auto const& import: module.imports) {
     ensureCondition(


### PR DESCRIPTION
this should be used on the testnet until the metering contract is fixed.