### PR TITLE
Rethrow EEI exceptions in WAVM

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -231,7 +231,7 @@ jobs:
       CC:  clang
       GENERATOR: Ninja
       BUILD_PARALLEL_JOBS: 4
-      CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=OFF -DHERA_WAVM=ON -DHERA_WABT=ON -DEVMC_TESTING=ON -DSANITIZE=address
+      CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=ON -DHERA_DEBUGGING=ON -DHERA_WAVM=ON -DHERA_WABT=ON -DEVMC_TESTING=ON -DSANITIZE=address
       # The ASan must the first loaded shared library. Force preloading it with this flag.
       PRELOAD_ASAN: true
     docker:

--- a/circle.yml
+++ b/circle.yml
@@ -169,6 +169,8 @@ defaults:
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.$SO --singlenet Byzantium --singletest "getGasLeftUseAllGas" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.$SO --singlenet Byzantium --singletest "returnPredefinedData" --evmc engine=wavm
         testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.$SO --singlenet Byzantium --singletest "getCaller" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.$SO --singlenet Byzantium --singletest "returnVeryLong" --evmc engine=wavm
+        testeth -t GeneralStateTests/stEWASMTests -- --testpath tests --vm ~/build/src/libhera.$SO --singlenet Byzantium --singletest "revertVeryLong" --evmc engine=wavm
 
   evmc-test: &evmc-test
     run:

--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -75,6 +75,9 @@ namespace wavm_host_module {
   // first the ethereum interface(s), the top of the stack is used in host functions
   stack<WavmEthereumInterface*> interface;
 
+  // set up for re-throwing exceptions, this is not clean, but Hera and WAVM are incompatible without some awkwardness
+  std::exception_ptr eei_exception_ptr = nullptr;
+  bool VMTrapFlag = false;
 
   // the host module is called 'ethereum'
   DEFINE_INTRINSIC_MODULE(ethereum)
@@ -83,31 +86,83 @@ namespace wavm_host_module {
   // host functions follow
   DEFINE_INTRINSIC_FUNCTION(ethereum, "useGas", void, useGas, I64 amount)
   {
-    interface.top()->eeiUseGas(amount);
+    try {
+      interface.top()->eeiUseGas(amount);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "getAddress", void, getAddress, U32 resultOffset)
   {
-    interface.top()->eeiGetAddress(resultOffset);
+    try {
+      interface.top()->eeiGetAddress(resultOffset);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "call", U32, call, I64 gas, U32 addressOffset, U32 valueOffset, U32 dataOffset, U32 dataLength)
   {
-    return interface.top()->eeiCall(EthereumInterface::EEICallKind::Call, gas, addressOffset, valueOffset, dataOffset, dataLength);
+    U32 ret;
+    try {
+      ret = interface.top()->eeiCall(EthereumInterface::EEICallKind::Call, gas, addressOffset, valueOffset, dataOffset, dataLength);
+      // Now that we have returned from the contract call, must clear out any exception occurring in the contract called. Note that the following code is skipped if an exception occurred when trying to call.
+      eei_exception_ptr = nullptr;
+      VMTrapFlag = false;
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
+    return ret;
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "callDataCopy", void, callDataCopy, U32 resultOffset, U32 dataOffset, U32 length)
   {
-    interface.top()->eeiCallDataCopy(resultOffset, dataOffset, length);
+    try {
+      interface.top()->eeiCallDataCopy(resultOffset, dataOffset, length);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "getCallDataSize", U32, getCallDataSize)
   {
-    return interface.top()->eeiGetCallDataSize();
+    U32 ret;
+    try {
+      ret = interface.top()->eeiGetCallDataSize();
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
+    return ret;
   }
 
 
@@ -119,55 +174,142 @@ namespace wavm_host_module {
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "getGasLeft", U64, getGasLeft)
   {
-    return static_cast<U64>(interface.top()->eeiGetGasLeft());
+    U64 ret;
+    try {
+      ret = static_cast<U64>(interface.top()->eeiGetGasLeft());
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
+    return ret;
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "storageStore", void, storageStore, U32 pathOffset, U32 valueOffset)
   {
-    interface.top()->eeiStorageStore(pathOffset, valueOffset);
+    try {
+      interface.top()->eeiStorageStore(pathOffset, valueOffset);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "storageLoad", void, storageLoad, U32 pathOffset, U32 valueOffset)
   {
-    interface.top()->eeiStorageLoad(pathOffset, valueOffset);
+    try {
+      interface.top()->eeiStorageLoad(pathOffset, valueOffset);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "codeCopy", void, codeCopy, U32 resultOffset, U32 codeOffset, U32 length)
   {
-    interface.top()->eeiCodeCopy(resultOffset, codeOffset, length);
+    try {
+      interface.top()->eeiCodeCopy(resultOffset, codeOffset, length);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "getCodeSize", U32, getCodeSize)
   {
-    return interface.top()->eeiGetCodeSize();
+    U32 ret;
+    try {
+      ret =interface.top()->eeiGetCodeSize();
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
+    return ret;
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "finish", void, finish, U32 dataOffset, U32 length)
   {
-    interface.top()->eeiFinish(dataOffset, length);
+    try {
+      interface.top()->eeiFinish(dataOffset, length);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "revert", void, revert, U32 dataOffset, U32 length)
   {
-    interface.top()->eeiRevert(dataOffset, length);
+    try {
+      interface.top()->eeiRevert(dataOffset, length);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "getReturnDataSize", U32, getReturnDataSize)
   {
-    return interface.top()->eeiGetReturnDataSize();
+    U32 ret;
+    try {
+      ret = interface.top()->eeiGetReturnDataSize();
+    } catch (HeraException const& e) {
+      HERA_DEBUG<<"caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
+    return ret;
   }
 
 
   DEFINE_INTRINSIC_FUNCTION(ethereum, "returnDataCopy", void, returnDataCopy, U32 resultOffset, U32 dataOffset, U32 length)
   {
-    interface.top()->eeiReturnDataCopy(resultOffset, dataOffset, length);
+    try {
+      interface.top()->eeiReturnDataCopy(resultOffset, dataOffset, length);
+    } catch (HeraException const& e) {
+      HERA_DEBUG << "caught Hera's Exception\n";
+      // save exception so that we can rethrow it once WAVM returns from the invocation
+      eei_exception_ptr = std::current_exception();
+      // clear pointer to memory and trigger WAVM halt so that WAVM cleans up and exits
+      interface.top()->setWasmMemory(nullptr);
+      throwException(Runtime::Exception::calledUnimplementedIntrinsicType); //or maybe reachedUnreachableType
+    }
   }
 
 
@@ -195,6 +337,7 @@ namespace wavm_host_module {
   };
 } // namespace wavm_host_module
 
+
 ExecutionResult WavmEngine::execute(
   evmc_context* context,
   vector<uint8_t> const& code,
@@ -202,9 +345,35 @@ ExecutionResult WavmEngine::execute(
   evmc_message const& msg,
   bool meterInterfaceGas
 ) {
-  ExecutionResult result = internalExecute(context, code, state_code, msg, meterInterfaceGas);
-  // And clean up mess left by this run.
+
+  // clear stuff from previous run
+  wavm_host_module::eei_exception_ptr = nullptr;
+  wavm_host_module::VMTrapFlag = false;
+
+  // hope and prayer
   Runtime::collectGarbage();
+
+  // execute the contract
+  ExecutionResult result;
+  try {
+    result = internalExecute(context, code, state_code, msg, meterInterfaceGas);
+
+    // throw VMTrap exception if there was an exception thrown by WAVM and not by us
+    if(wavm_host_module::VMTrapFlag)
+      ensureCondition(false, VMTrap, "hera exception from WAVM VM Trap")
+
+    // re-throw exception if there was one
+    if (wavm_host_module::eei_exception_ptr)
+      std::rethrow_exception (wavm_host_module::eei_exception_ptr);
+  } catch (EndExecution const&) {
+      HERA_DEBUG << "caught Hera's EndExecution\n";
+      // This exception is ignored here because we consider it to be a success.
+      // It is only a clutch for POSIX style exit()
+  }
+
+  // clean up this run, this is done here after leaving the scope of internalExecute()
+  Runtime::collectGarbage();
+
   return result;
 }
 
@@ -273,22 +442,30 @@ ExecutionResult WavmEngine::internalExecute(
   // this is how WAVM's try/catch for exceptions
   Runtime::catchRuntimeExceptions(
     [&] {
-      try {
         vector<IR::Value> invokeArgs;
         Runtime::invokeFunctionChecked(wavm_context, mainFunction, invokeArgs);
-      } catch (EndExecution const&) {
-        // This exception is ignored here because we consider it to be a success.
-        // It is only a clutch for POSIX style exit()
-      }
+        // wavm may have cleaned up the memory, so make sure we can't access it
+        wavm_host_module::interface.top()->setWasmMemory(nullptr);
     },
     [&](Runtime::Exception&& exception) {
-      // FIXME: decide if each of the exception fit into VMTrap/InternalError
-      ensureCondition(false, VMTrap, Runtime::describeException(exception));
+      HERA_DEBUG << "caught WAVM's Runtime::Exception\n";
+      // wavm may have cleaned up the memory, so make sure we can't access it
+      wavm_host_module::interface.top()->setWasmMemory(nullptr);
+      // if WAVM threw an exception and we did not, then make a note so we can throw a corresponding hera exception
+      if (wavm_host_module::eei_exception_ptr == nullptr)
+        wavm_host_module::VMTrapFlag = true;
     }
   );
 
   // clean up
+  wavm_host_module::interface.top()->setWasmMemory(nullptr);
   wavm_host_module::interface.pop();
+  compartment = nullptr;
+  wavm_context = nullptr;
+  ethereumHostModule = nullptr;
+  moduleInstance = nullptr;
+  mainFunction = nullptr;
+  Runtime::collectGarbage();
 
   return result;
 }


### PR DESCRIPTION
Passes the following tests `useGas`, `getCallDataSize`, `callDataCopy`, `callDataCopy256`, `revert`, `returnPredefinedData`, `revertVeryLong`, and `returnVeryLong`.

Each host function which can throw a hera exception has a try-catch to catch and record this exception, trigger a WAVM trap so that it can clean up. Once WAVM returns, we re-throw the original hera exception.

Don't know if this is what you wanted. If not, I will close.