### PR TITLE
Remove evmc_address comparator helpers

### DIFF
--- a/src/hera.cpp
+++ b/src/hera.cpp
@@ -26,6 +26,7 @@
 #include <map>
 
 #include <evmc/evmc.h>
+#include <evmc/helpers.hpp>
 
 #include "binaryen.h"
 #include "debugging.h"
@@ -43,15 +44,6 @@
 
 using namespace std;
 using namespace hera;
-
-// FIXME: should be part of EVMC
-bool operator==(evmc_address const& lhs, evmc_address const& rhs) {
-  return memcmp(lhs.bytes, rhs.bytes, sizeof(lhs.bytes)) == 0;
-}
-
-bool operator<(evmc_address const& lhs, evmc_address const& rhs) {
-  return memcmp(lhs.bytes, rhs.bytes, sizeof(lhs.bytes)) < 0;
-}
 
 namespace {
 


### PR DESCRIPTION
These are provided by EVMC 6.0.0

Fixes #443.