### PR TITLE
Initial support for runevm contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ These are to be used via EVMC `set_option`:
 - `reject` will reject any EVM1 bytecode with an error (the default setting)
 - `fallback` will allow EVM1 bytecode to be passed through to the client for execution
 - `evm2wasm` will enable transformation of bytecode using the [EVM Transcompiler]
+- `runevm` will transform EVM1 bytecode using [runevm]
 
 ## Interfaces
 
@@ -129,3 +130,4 @@ Apache 2.0
 [Sentinel system contract]: https://github.com/ewasm/design/blob/master/system_contracts.md#sentinel-contract
 [EVM Transcompiler]: https://github.com/ewasm/design/blob/master/system_contracts.md#evm-transcompiler
 [EEI]: https://github.com/ewasm/design/blob/master/eth_interface.md
+[runevm]: https://github.com/axic/runevm


### PR DESCRIPTION
This PR adds runevm as a system contract. I wanted to be able to test runevm via `testeth`, and made these changes to facilitate that. Not sure if this is something that you'd want merged.

Just now when I wanted to push my branch name conflicted with https://github.com/ewasm/hera/tree/runevm and I found this commit https://github.com/ewasm/hera/commit/866e12c90f644d834eb68836c700ba82c3d90267 (Update: just saw the PR https://github.com/ewasm/hera/pull/375) which would have saved me a day! :)

Three points about the PR:

- I couldn't get `context->host->call` to work, and directly use the `WasmEngine` to call runevm.
- When the runevm instance was being instantiated it would cause out-of-bounds memory access so I added the `module.memory.initial = 20` to avoid that. Not sure how to properly handle this.
- Added a flag `disable-interface-metering`, as runevm currently measures all gas costs itself (again, not sure if this is good or not).