### PR TITLE
CMake: Hide symbols from wasm engines included

### DIFF
--- a/cmake/ProjectWAVM.cmake
+++ b/cmake/ProjectWAVM.cmake
@@ -24,6 +24,7 @@ set(llvmjit_library ${binary_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LLVMJIT${CMA
 
 set(other_libraries ${platform_library} ${wasm_library} ${ir_library} ${logging_library} ${unwind_library} ${llvmjit_library})
 
+set(flags "-Wno-error -fvisibility=hidden")
 
 ExternalProject_Add(wavm
     PREFIX ${prefix}
@@ -41,7 +42,8 @@ ExternalProject_Add(wavm
     -DCMAKE_BUILD_TYPE=Release
     -DLLVM_DIR=${LLVM_DIR}
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    -DCMAKE_CXX_FLAGS=-Wno-error
+    -DCMAKE_CXX_FLAGS=${flags}
+    -DCMAKE_C_FLAGS=${flags}
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${runtime_library} ${other_libraries}
 )

--- a/cmake/ProjectWabt.cmake
+++ b/cmake/ProjectWabt.cmake
@@ -26,6 +26,8 @@ ExternalProject_Add(wabt
     -DBUILD_TESTS=OFF
     -DBUILD_TOOLS=OFF
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -DCMAKE_CXX_FLAGS=-fvisibility=hidden
+    -DCMAKE_C_FLAGS=-fvisibility=hidden
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${wabt_library}
 )


### PR DESCRIPTION
For binaryen + wabt:
```
nm -Cg src/libhera.so | wc -l 
readelf -r src/libhera.so | wc -l
```

Before: 9852 10831
After: 3993 6510