### PR TITLE
Use memoryRef and not memoryArrayPtr for single elements in WAVM 

### DIFF
--- a/src/wavm.cpp
+++ b/src/wavm.cpp
@@ -61,8 +61,8 @@ public:
 private:
   // These assume that m_wasmMemory was set prior to execution.
   size_t memorySize() const override { return Runtime::getMemoryNumPages(m_wasmMemory) * 65536; }
-  void memorySet(size_t offset, uint8_t value) override { (Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, 1))[0] = value; }
-  uint8_t memoryGet(size_t offset) override { return (Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, 1))[0]; }
+  void memorySet(size_t offset, uint8_t value) override { Runtime::memoryRef<U8>(m_wasmMemory, offset) = value; }
+  uint8_t memoryGet(size_t offset) override { return Runtime::memoryRef<U8>(m_wasmMemory, offset); }
   uint8_t* memoryPointer(size_t offset, size_t length) override {
     ensureCondition(memorySize() >= (offset + length), InvalidMemoryAccess, "Memory is shorter than requested segment");
     return Runtime::memoryArrayPtr<U8>(m_wasmMemory, offset, length);


### PR DESCRIPTION
`memoryRef` code is [here](https://github.com/WAVM/WAVM/blob/fa5434e03efbc2154ecf4aafede169da76a4da40/Include/Runtime/Runtime.h#L294) in WAVM.