### PR TITLE
ci: upgrade macos dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -307,7 +307,9 @@ jobs:
       - run:
           name: "Install system dependencies"
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install -q cmake ninja leveldb
+            # Update homebrew to hopefully >=3.2 so that reliance on bintray is removed
+            HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew update
+            HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install cmake ninja leveldb
       - checkout
       - *update-submodules
       - *environment-info


### PR DESCRIPTION
This is needed because went out of service. See https://bintray.com/ and https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

So apparently homebrew will still work, as it has a list of URLs, just keep complaining about bintray.